### PR TITLE
Fix typos and other minor errors

### DIFF
--- a/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
+++ b/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
@@ -30,7 +30,7 @@ Let's build our first component, which will display `Hello World!` inside a `div
 
 There are a couple of things to note in our first component:
 
-- Our component name, `HelloWorld`, is title-cased (sometimes referred to as _Pascal_ case). This is intentional and we'll discuss this convention shorty.
+- Our component name, `HelloWorld`, is title-cased (sometimes referred to as _Pascal_ case). This is intentional and we'll discuss this convention shortly.
 - Our component returns something that looks a lot like HTML, but isn't&mdash;it's _JSX_. We'll devote the whole next section to talking about JSX.
 
 <FrameworkAside framework="react">
@@ -133,7 +133,7 @@ const style = { "background-color": "#2c4f7c", color: "#FFF" };
 
 All of a sudden, we have code that lets us take advantage of the dynamic nature of JavaScript with a declarative HTML-like syntax.
 
-As we progress through these tutorials, we'll discover how Solid's reactive system combines with JSX to make for a delighful experience when crafting user interfaces.
+As we progress through these tutorials, we'll discover how Solid's reactive system combines with JSX to make for a delightful experience when crafting user interfaces.
 
 ### Using custom components in JSX
 
@@ -161,7 +161,7 @@ We can now, in turn, use `HelloWorld` as a JSX component _inside_ another compon
   }}
 />
 
-`MyApp` is a component that displays some header text, `Welcome`, alongside our `HelloWorld` component. We're starting to get a sense of the _composability_ of JSX: we have a good bit of information inside our `HelloWorld` component that can now be used very simply inside the `myApp` component!
+`MyApp` is a component that displays some header text, `Welcome`, alongside our `HelloWorld` component. We're starting to get a sense of the _composability_ of JSX: we have a good bit of information inside our `HelloWorld` component that can now be used very simply inside the `MyApp` component!
 
 ### Using fragments
 
@@ -225,11 +225,11 @@ Solid provides a `render` function that will render our app inside this `div`:
 
 This snippet creates our `HelloWorld` component, checks to see if our root node exists, and inserts within that DOM node. At this point, we have built a representation of our user interface in JavaScript and Solid has added it to the DOM: everything needed for us to see our simple Hello World application on a web page!
 
-**Note:** The `render` function _also_ is also doing some magic behind the scenes that enables Solid's _reactive system_, so you'll want to make sure the first argument passed to the render function is a function that returns a component `() => <Component />` rather than just the component itself.
+**Note:** The `render` function is also doing some magic behind the scenes that enables Solid's _reactive system_, so you'll want to make sure the first argument passed to the render function is a function that returns a component `() => <Component />` rather than just the component itself.
 
 ## Composing multiple components together
 
-In most cases, out applications are big enough that we will want to split them into _multiple_ components. Let's move on from our `HelloWorld` example to build something a little bigger&mdash;a virtual bookshelf. Our bookshelf will allow us to add books, mark books as "read," and eventually fetch book titles from other services on the Internet.
+In most cases, our applications are big enough that we will want to split them into _multiple_ components. Let's move on from our `HelloWorld` example to build something a little bigger&mdash;a virtual bookshelf. Our bookshelf will allow us to add books, mark books as "read", and eventually fetch book titles from other services on the Internet.
 
 Given the intuitive nature of JSX, we can plan out our application a bit. Our main `Bookshelf` will be comprised of two top-level components:
 
@@ -279,11 +279,11 @@ Finally, we can _compose_ our `BookList` and `AddBook` components together insid
 
 ### Component relationships
 
-There are a couple terms worth learning when we talk about how components relate to one another&mdash;_parent_ and _child_. In our `Bookshelf` example, the `Bookshelf` component is called the _parent_ of both `Books` and `AddBook` because those two components are within `Bookshelf`. Accordingly, `Books` and `AddBook` are _children_ of `Bookshelf`. You may already be familiar with this terminology; it's how we tend to refer to HTML element relationships in our DOM tree.
+There are a couple terms worth learning when we talk about how components relate to one another&mdash;_parent_ and _child_. In our `Bookshelf` example, the `Bookshelf` component is called the _parent_ of both `BookList` and `AddBook` because those two components are within `Bookshelf`. Accordingly, `BookList` and `AddBook` are _children_ of `Bookshelf`. You may already be familiar with this terminology; it's how we tend to refer to HTML element relationships in our DOM tree.
 
 ### Passing props between components
 
-Components can communicate with their children components by passing properties, which are commonly called `props`. To demonstrate the power of `props`, let's customize our bookshelf by adding our name to it! In the example below, we update our app to display "Solid's Bookshelf," but you should use your own name.
+Components can communicate with their child components by passing properties, which are commonly called `props`. To demonstrate the power of `props`, let's customize our bookshelf by adding our name to it! In the example below, we update our app to display "Solid's Bookshelf," but you should use your own name.
 
 <CodeTabs
   files={{


### PR DESCRIPTION
Fix typos and other minor errors (e.g. component name consistency) in Building User Interfaces with Components