### PR TITLE
fix: minor typo in Vue comparison docs

### DIFF
--- a/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
+++ b/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
@@ -193,7 +193,7 @@ However, we may not actually _want_ a `<div />` (or some other element) surround
 Now we have valid JSX but we won't have a containing element rendered to the DOM.
 
 <FrameworkAside framework="vue">
-  Vue 2 worked similarly: a component needed to have a single root ekement.
+  Vue 2 worked similarly: a component needed to have a single root element.
 </FrameworkAside>
 
 ### JSX is compiled


### PR DESCRIPTION
This PR fixes an extremely minor typo from `ekement` to `element`. 

I'll have more substantial docs contributions soon