### PR TITLE
docs: Add aside mentioning React's StrictMode

### DIFF
--- a/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
+++ b/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
@@ -227,6 +227,14 @@ This snippet creates our `HelloWorld` component, checks to see if our root node 
 
 **Note:** The `render` function is also doing some magic behind the scenes that enables Solid's _reactive system_, so you'll want to make sure the first argument passed to the render function is a function that returns a component `() => <Component />` rather than just the component itself.
 
+<FrameworkAside framework="react">
+
+React defaults to having a `StrictMode` component added to the root of your app, which [changes the render behavior of your code dependant if you're in a development mode or not](https://beta.reactjs.org/learn/keeping-components-pure#side-effects-unintended-consequences:~:text=Detecting%20impure%20calculations%20with%20StrictMode).
+
+Solid has no such behavioral differences between production and development rendering.
+
+</FrameworkAside>
+
 ## Composing multiple components together
 
 In most cases, our applications are big enough that we will want to split them into _multiple_ components. Let's move on from our `HelloWorld` example to build something a little bigger&mdash;a virtual bookshelf. Our bookshelf will allow us to add books, mark books as "read", and eventually fetch book titles from other services on the Internet.


### PR DESCRIPTION
This PR introduces a mention of React's StrictMode, which has different behavior from production vs development. 

> One of the primary differences in production vs development is that `useEffect` runs twice within a component

I thought this was a useful distinction that helps sell Solid to some React developers, where this has become a somewhat divisive decision, regardless of its benifits.