### PR TITLE
docs: Create initial aside of `For` and `Index`

### DIFF
--- a/src/routes/guides/getting-started-with-solid/adding-interactivity-with-state.mdx
+++ b/src/routes/guides/getting-started-with-solid/adding-interactivity-with-state.mdx
@@ -62,12 +62,12 @@ console.log(count()); // 0
 ```
 
 <FrameworkAside framework="svelte">
-  This is equivalent to `let count = 0` in Svelte. 
-  
+  This is equivalent to `let count = 0` in Svelte.
+
   In Svelte, you can use your
   reactive value without calling it like a function. That's because Svelte's
   reactivity uses a compiler, whereas Solid's reactivity is part of the library.
-  Because we're working within the restrictions of JavaScript, we need to run code when we access the value so that we can 
+  Because we're working within the restrictions of JavaScript, we need to run code when we access the value so that we can
   tell the reactive system, "This value is used here!"
 </FrameworkAside>
 <FrameworkAside framework="react">
@@ -257,6 +257,35 @@ Our `BookList` component now looks like this:
     ],
   }}
 />
+
+Solid's `For` component also supports the ability to assign a `key` for each item in the list in order to do index tracking.
+
+<Aside title="Read more about index tracking (optional)" type="advanced" collapsible>
+Let's assume that you have a list of items that you want to render using the `For` component:
+
+```jsx
+<For each={books()}></For>
+```
+
+In its initial render, this `For` renders two books since `books()` has an initial array value of two items.
+
+Later, you attempt to [re-fetch the books list from an external API](/guides/getting-started-with-solid/fetching-data),
+which creates a new object reference for each item in the array, despite containing the same information in the same order.
+
+Solid, seeing a new list of items, re-renders the lists. Because the object references have changed, despite the
+information remaining consistent, it will trigger a re-render of every item in the list: A unoptimized process.
+
+Ideally, we could tell Solid to simply render the DOM nodes based on the index rather than object reference.
+That way, Solid wouldn't re-render DOM nodes that already contained up-to-date information thanks to remaining in the
+same index.
+
+Luckily, there's an easy way to do this: Simply replace the `For` component with the `Index` component:
+
+```jsx
+<Index items={books()}></Index>
+```
+
+</Aside>
 
 ## Derived state
 


### PR DESCRIPTION
This PR creates an early look at an aside for `Index` that helps explain why it exists and that there's more going on under-the-hood with `For`.

# Concerns With Approach

- I don't like that this utilizes fetching, which requires referencing a future chapter
- This needs images, waiting on #30 to add
- Using object reference as the example instead of primitives might cause more questions than answers ("how to track by ID")

# After Merge TODOs

- [ ] `FrameworkAside` that Angular's default `ngFor` uses the same object reference tracking that `For` does, showcase what `Index` is doing by a custom `trackBy` method (relies on  #31 merged first)
- [ ] Show React Aside of `Index` and `For` using `key` values
- [ ] Show Vue Aside of `Index` and `For` using `key` values