### PR TITLE
fix: Update style binding Vue snippet

### DIFF
--- a/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
+++ b/src/routes/guides/getting-started-with-solid/building-ui-with-components.mdx
@@ -140,7 +140,7 @@ As we progress through these tutorials, we'll discover how Solid's reactive syst
 This syntax of binding HTML and attribute values are two different syntaxes in Vue. The above might look something like this in Vue:
 
 ```html
-<div v-on:style="style">Hello {{name}}!</div>
+<div :style="style">Hello {{name}}!</div>
 ```
 
 </FrameworkAside>


### PR DESCRIPTION
`v-on` is used when you want to attach an event listener to the element. Since we just want to bind the styles to the element and not listen for the "styles" event, we can remove the `v-on`. (You can also replace the `v-on` with `v-bind` but this is not the recommended approach anymore if you look through the docs.)

References:
- [`v-on`](https://vuejs.org/api/built-in-directives.html#v-on)
- [`v-bind`](https://vuejs.org/api/built-in-directives.html#v-bind)
- [Style binding in Vue](https://vuejs.org/guide/essentials/class-and-style.html#binding-inline-styles)