### PR TITLE
Fix icons alignment

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
     <footer class="flex flex-col sm:flex-row justify-between pb-8 border-t-1 border-dotted pt-10">
       <HelpButton />
 
-      <a class="flex gap-2 hover:underline" href={url()}>
+      <a class="flex items-center gap-2 hover:underline" href={url()}>
         <IconEdit></IconEdit> Edit this page
       </a>
     </footer>

--- a/src/components/footer/HelpButton.tsx
+++ b/src/components/footer/HelpButton.tsx
@@ -3,7 +3,7 @@ import IconDiscord from "~icons/ic/baseline-discord";
 export const HelpButton = () => {
   return (
     <a
-      class="flex gap-2 hover:underline"
+      class="flex items-center gap-2 hover:underline"
       href="https://discord.com/invite/solidjs"
     >
       <IconDiscord /> Need help? Don't hesitate to ask us on Discord!


### PR DESCRIPTION
Fixes #79 

This PR centralizes the icon and text of the Help/Edit links:
![image](https://user-images.githubusercontent.com/61414485/176053903-153cdde2-da99-4024-b238-e90c011a4585.png)
