### PR TITLE
Fix sidebar scrolling bug and reorder semantic hierarchy

### DIFF
--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -341,9 +341,9 @@ function SectionNav(props: { sections: SECTIONS }) {
       <For each={sectionNames}>
         {(name, i) => (
           <li>
-            <h1 class="pl-4 text-solid-dark dark:text-white font-bold text-xl">
+            <h2 class="pl-4 text-solid-dark dark:text-white font-bold text-xl">
               {props.sections[name].name}
-            </h1>
+            </h2>
             <SectionsNavIterate pages={props.sections[name].pages} />
             {i() !== sectionNames.length - 1 ? (
               <hr class="w-full mb-2" />

--- a/src/components/nav/NavHeader.tsx
+++ b/src/components/nav/NavHeader.tsx
@@ -38,7 +38,7 @@ export const NavHeader = (props: {
     <nav
       aria-label="Docs header navigation"
       role="navigation"
-      class="bg-white dark:bg-solid-darkbg sticky top-0 items-center w-full px-5 pt-8 pb-4"
+      class="bg-white dark:bg-solid-darkbg sticky top-0 items-center w-full px-5 pt-8 pb-4 z-1"
     >
       <div class="flex items-center justify-between">
         <NavLink


### PR DESCRIPTION
- Closes #83 

This PR fixes the issues listed in issue #83, here's a GIF showing the fixed sidebar (without the scrolling bug):

![image](https://i.imgur.com/gfCkQhn.gif)
