### PR TITLE
Remove 404 page overflowing width and center text on mobile

### DIFF
--- a/src/routes/[...404].tsx
+++ b/src/routes/[...404].tsx
@@ -1,6 +1,6 @@
 export default function () {
   return (
-    <div class="lg:w-5xl h-full mt-12 flex flex-col justify-center items-center">
+    <div class="h-full mt-12 flex flex-col justify-center items-center text-center">
       <div class="font-bold text-xl">404</div>
       <div class="font-bold text-xl">This page doesn't quite exist yet</div>
     </div>


### PR DESCRIPTION
- Closes #89

The issue has images showing the problems, here's a gif showing that the page isn't overflowing and the text on mobile is now being centered:

![iehAwzw](https://user-images.githubusercontent.com/61414485/176794246-e3ab61a2-ecf1-413a-a006-7698df9849d6.gif)

