### PR TITLE
Start: update "CSS and Styling" page to have a correct example of CSS modules

### DIFF
--- a/content/start/core-concepts/css-and-styling.mdx
+++ b/content/start/core-concepts/css-and-styling.mdx
@@ -48,16 +48,16 @@ div.card > p {
 
 Solid-start also supports [vite's CSS modules](https://vitejs.dev/guide/features.html#css-modules). Through [CSS modules](https://github.com/css-modules/css-modules), you can scope certain CSS to a component. This means that you can use the same CSS class in two components, and have both of them styled differently.
 
-To use the feature, change the file extension from `.css` to `.module.css` and update the import accordingly.
+To use the feature, change the file extension from `.css` to `.module.css` (or from `.scss` or `.sass` to `.module.scss` or `.module.sass`) and update the import accordingly.
 
 You will notice that suddenly your CSS stops working! This is because behind the scenes, classes defined in the CSS module are being renamed to a series of random letters. When we hard code classes using the class attribute (`class="card"`), solid does not know it should rename card to something different.
 
 To fix this, you can import classes used in your CSS module. You can think of this import as a object of `humanClass: generatedClass`. We reference the key (the class name we wrote!), and get back the unique, generated class name.
 
 ```tsx
-import * as cardCss from "./Card.module.css"
+import styles from "./Card.module.css"
 function Card(props) {
-  return (<div class={`${cardCss.card}`}>{props.text}</button>)
+  return (<div class={styles.card}>{props.text}</div>)
 }
 ```
 


### PR DESCRIPTION
Changed the example of how to use CSS modules to something that works with typescript (and is generally the best and recommended way to do it)

#45 