### PR TITLE
corrected the use of types and changed double to multiplicator

### DIFF
--- a/content/how-to-guides/get-ready-for-solid/javascript-for-solid.mdx
+++ b/content/how-to-guides/get-ready-for-solid/javascript-for-solid.mdx
@@ -313,4 +313,4 @@ Here, we accomplished the same thing in one line of code by using the `filter` a
 
 When we say we write "declarative code", we mean that we make use of abstractions to write code that is more streamlined: focused more on _what_ we are trying to accomplish than exactly _how_. Using `filter` allows us to write less "boilerplate" looping code, and instead focus on the core functionality that we want. The code is simpler to read: `for` loops can be used for all sorts of purposes, but whenever you see `filter` you know that the purpose of the looping is to ignore some items in an array.
 
-HTML is a great example of a _declarative_ way of writing: you state _what_ you want the structure to be, not _how_ it should be put together or rendered. As we hope to show you in this tutorial, Solid makes it easier to write declarative code when working with UIs.
+HTML is a great example of a _declarative_ way of writing: you state _what_ you want the structure to be, not _how_ it should be put together or rendered. As we hope to show you in this guide, Solid makes it easier to write declarative code when working with UIs.

--- a/content/how-to-guides/get-ready-for-solid/javascript-for-solid.mdx
+++ b/content/how-to-guides/get-ready-for-solid/javascript-for-solid.mdx
@@ -73,7 +73,7 @@ console.log(areaOfCircle(4));
 There are many ways of doing object-oriented programming in JavaScript, but the most common you'll find alongside Solid is the technique of defining a function that returns an object.
 
 ```js
-function createCar(make: string, year: number) {
+function createCar(make, year) {
   const currentYear = new Date().getFullYear();
   const age = currentYear - year;
 
@@ -120,8 +120,8 @@ function multiplyBy(multiplier) {
   };
 }
 
-const double = multiplyBy(2);
-console.log(double(7)); //14
+const multiplicator = multiplyBy(2);
+console.log(multiplicator(7)); //14
 ```
 
 ## Destructuring


### PR DESCRIPTION
I removed the use of types in the javascript examples and changed the name of double to multiplicator as it might confuse some developers that are coming from other languages. 