### PR TITLE
improve anchor text accessibility

### DIFF
--- a/src/md.tsx
+++ b/src/md.tsx
@@ -84,7 +84,7 @@ export default {
     return (
       <Link
         {...props}
-        class="dark:text-link-dark break-normal border-b border-solid-default hover:text-solid-default hover:dark:text-solid-light focus:text-solid-default focus:dark:text-solid-light duration-100 ease-in transition font-semibold leading-normal"
+        class="dark:text-link-dark break-normal border-b border-solid-default dark:border-solid-light hover:text-solid-default hover:dark:text-solid-light focus:text-solid-default focus:dark:text-solid-light duration-100 ease-in transition font-semibold leading-normal"
       >
         {props.children}
       </Link>

--- a/src/md.tsx
+++ b/src/md.tsx
@@ -84,7 +84,7 @@ export default {
     return (
       <Link
         {...props}
-        class="dark:text-link-dark break-normal border-b border-solid-default border-opacity-0 hover:border-opacity-100 duration-100 ease-in transition font-semibold leading-normal"
+        class="dark:text-link-dark break-normal border-b border-solid-default hover:text-solid-default hover:dark:text-solid-light focus:text-solid-default focus:dark:text-solid-light duration-100 ease-in transition font-semibold leading-normal"
       >
         {props.children}
       </Link>


### PR DESCRIPTION
Was looking through the solid docs and didn't even realize the bold text were links until I accidentally pressed one. Added some styles to make links more obvious.