### PR TITLE
Update: Fix spelling mistake

### DIFF
--- a/content/guides/how-to-guides/styling-in-solid/less.mdx
+++ b/content/guides/how-to-guides/styling-in-solid/less.mdx
@@ -16,7 +16,7 @@ yarn add --dev less         # Using yarn
 
 ## Using LESS In Your App
 
-Let's create a `.less` file in our `src` directory and name it style.less
+Let's create a `.less` file in our `src` directory and name it `styles.less`
 
 ```less
 //styles.less


### PR DESCRIPTION
After reading the full post, we can see that the name of the `less` file should be called `styles.less` instead of `style.less`.