### PR TITLE
Update: fix the code block

### DIFF
--- a/content/references/concepts/tracking/index.mdx
+++ b/content/references/concepts/tracking/index.mdx
@@ -16,12 +16,12 @@ This doesn't just apply to signals created with `createSignal` - props and store
 
 ## Example
 
-````jsx
+```jsx
 function Counter() {
   const [count, setCount] = createSignal(0);
   const increment = () => setCount(count() + 1);
 
-  /* When count() is called, the count" signal is tracked as a subscription of this effect,
+  /* When count() is called, the "count" signal is tracked as a subscription of this effect,
     so this code reruns when (and only when) count changes */
   createEffect(() => {
     console.log("My effect says " + count());
@@ -40,10 +40,8 @@ function Counter() {
       {count()}
     </button>
   );
-}```
-
-
-````
+}
+```
 
 ## Tracking Gotchas
 


### PR DESCRIPTION
## Description

- There are 3 redundant backticks at the end of the code block.
- The comment is missing a double quote.