### PR TITLE
Small stylistic changes

### DIFF
--- a/src/components/Dot.tsx
+++ b/src/components/Dot.tsx
@@ -1,6 +1,6 @@
 export default function Dot(props: { number: number }) {
   return (
-    <div class="rounded-full pt-1 min-w-6 w-6 h-6 border border-solid-lightitem dark:border-solid-darkitem grid place-content-center bg-solid-light dark:bg-white text-solid-accent font-bold">
+    <div class="rounded-full min-w-6 w-6 h-6 border border-solid-lightitem dark:border-solid-darkitem grid place-content-center bg-solid-light dark:bg-white text-solid-accent font-bold">
       <span>{props.number}</span>
     </div>
   );

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -24,7 +24,7 @@ export default function Nav(props: { docsMode: "start" | "regular" }) {
 
   return (
     <div class="lg:max-h-screen lg:sticky lg:top-0 no-bg-scrollbar lg:min-w-[200px] lg:max-w-sm w-full shadow lg:shadow-none z-50 overflow-y-auto flex flex-col gap-8">
-      <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-4 lg:pr-3">
         <NavHeader
           docsMode={props.docsMode}
           showMenu={showMenu()}
@@ -32,7 +32,7 @@ export default function Nav(props: { docsMode: "start" | "regular" }) {
         />
       </div>
       {/* <div id="docsearch"></div> */}
-      <div class="hidden md:block">
+      <div class="hidden md:block lg:pr-3">
         <NavPreferences id="desktop" />
       </div>
       <div

--- a/src/components/nav/NavPreferences.tsx
+++ b/src/components/nav/NavPreferences.tsx
@@ -4,7 +4,7 @@ import IconChevron from "~icons/heroicons-outline/chevron-right";
 import { createSignal, Show } from "solid-js";
 
 export function NavPreferences(props: {id: string}) {
-  const [collapsed, setCollapsed] = createSignal(false);
+  const [collapsed, setCollapsed] = createSignal(true);
 
   return (
     <div class="border border-solid-lightitem bg-solid-light dark:bg-solid-dark dark:border-solid-darkitem rounded-lg">


### PR DESCRIPTION
This PR contains 3 different commits that establish the following small tweaks:

- Dot.tsx `pt-1` removed as it made the numbering in summary not vertically centered (Edge & Firefox, Windows 10)
- Nav.tsx, a small padding on the right was added to the header and prefs boxes, which did not look right on desktop. I kept the 0 padding on the menu items below because it does actually look good in those cases.
- NavPreferences.tsx, I made the prefs collapsed by default because it takes a lot of realestate and automatically reopens on reload or opening a new tab. A better solution would be to define the collapse state based on whether user config exists already.