### PR TITLE
fix: handle html element section title

### DIFF
--- a/src/components/context/PageStateContext.tsx
+++ b/src/components/context/PageStateContext.tsx
@@ -4,8 +4,10 @@ import { createEffect, useContext } from "solid-js";
 import { createContext, ParentProps } from "solid-js";
 import { createStore } from "solid-js/store";
 
+type SectionTitle = string | Element
+
 type Section = {
-  title: string;
+  title: SectionTitle | SectionTitle[];
   href: string;
 };
 

--- a/src/components/nav/Summary.tsx
+++ b/src/components/nav/Summary.tsx
@@ -4,6 +4,10 @@ import Dot from "../Dot";
 import IconChevron from "~icons/heroicons-outline/chevron-right";
 import { useRouteData } from "solid-start";
 
+function SectionTitle(props: { title: string | Element }) {
+    return props.title instanceof HTMLElement ? props.title.innerText : props.title
+}
+
 export default function Summary(props: {collapsed?: boolean}) {
     const { sections } = usePageState();
     const [collapsed, setCollapsed] = createSignal(props.collapsed || false);
@@ -28,7 +32,7 @@ export default function Summary(props: {collapsed?: boolean}) {
                 <li class="text-base py-2 hidden md:flex items-center gap-2 rounded hover:bg-solid-light hover:dark:bg-solid-darkbg px-2">
                     <Dot number={index() + 1} />
                     <a class="font-semibold" onClick={() => setCollapsed(true)} href={"#" + item.href}>
-                    {item.title}
+                    {Array.isArray(item.title) ? <For each={item.title}>{(title) => <SectionTitle title={title} />}</For> : <SectionTitle title={item.title} />}
                     </a>
                 </li>
                 )}
@@ -40,7 +44,7 @@ export default function Summary(props: {collapsed?: boolean}) {
                     <li class="text-base py-2 flex items-center gap-2 rounded hover:bg-solid-light hover:dark:bg-solid-darkbg px-2">
                         <Dot number={index() + 1} />
                         <a class="font-semibold" onClick={() => setCollapsed(true)} href={"#" + item.href}>
-                        {item.title}
+                        {Array.isArray(item.title) ? <For each={item.title}>{(title) => <SectionTitle title={title} />}</For> : <SectionTitle title={item.title} />}
                         </a>
                     </li>
                     )}


### PR DESCRIPTION
Attempt to fix #228 

Handle html elements within section titles by rendering the inner text if the title is a header. Not sure if this is the best way to solve this or if the title should try to render clones of the html nodes but is an improvement over rendering nothing

![solidjs-docs-summary-fix](https://user-images.githubusercontent.com/5996838/224600060-d38101b5-3424-4317-8f7d-ef55d48dbf1e.png)
