### PR TITLE
Reflect the real return's type of `from`

### DIFF
--- a/content/references/api-reference/reactive-utilities/from.mdx
+++ b/content/references/api-reference/reactive-utilities/from.mdx
@@ -9,7 +9,7 @@ function from<T>(
           fn: (v: T) => void
         ) => (() => void) | { unsubscribe: () => void };
       }
-): () => T;
+): () => T | undefined;
 ```
 
 A helper to make it easier to interop with external producers like RxJS observables or with Svelte Stores. This basically turns any subscribable (object with a subscribe method) into a Signal and manages subscription and disposal.


### PR DESCRIPTION
This is typed as `Accessor<T | undefined>` in Solid's typedefs:
https://github.com/solidjs/solid/blob/220a28967dfd9a4cc92e2390f61a88ffbb84a080/packages/solid/src/reactive/observable.ts#L91
