### PR TITLE
Follow updates for 1.7

### DIFF
--- a/content/guides/foundations/typescript-for-solid.mdx
+++ b/content/guides/foundations/typescript-for-solid.mdx
@@ -356,6 +356,7 @@ This is because `currentTarget` is the element that the
 event handler was attached to, so has a known type, whereas `target` is
 whatever the user interacted with that caused the event to bubble to or get
 captured by the event handler, which can be any DOM element.
+One exception is Input and Focus Events when attached directly to `input` elements will have HTMLInputElement as a `target`.
 
 ## The ref Attribute
 
@@ -480,19 +481,14 @@ Here are two workarounds for this issue:
 
    ```tsx
    return (
-     <Show when={name()}>{(n) => <>Hello {n.replace(/\s+/g, "\xa0")}!</>}</Show>
+     <Show when={name()}>{(n) => <>Hello {n().replace(/\s+/g, "\xa0")}!</>}</Show>
    );
    ```
 
    In this case, the typing of the `Show` component is clever enough to tell
    TypeScript that `n` is truthy, so it can't be `undefined` (or `null` or
    `false`).
-
-   Note, however, that this form of `<Show>` forces the entirety of the
-   children to render
-   from scratch every time `name()` changes, instead of doing this just when `name()` changes from a falsey to a truthy value.
-   This means that the children don't have the full benefits of fine-grained
-   reactivity (re-using unchanged parts and updating just what changed).
+   Remember this null asserted form will throw if accessed when the condition is no longer true.
 
 ## Special JSX Attributes and Directives
 

--- a/content/references/api-reference/control-flow/Show.mdx
+++ b/content/references/api-reference/control-flow/Show.mdx
@@ -7,8 +7,8 @@ function Show<T>(props: {
   when: T | undefined | null | false;
   keyed: boolean;
   fallback?: JSX.Element;
-  children: JSX.Element | ((item: T) => JSX.Element);
-}): () => JSX.Element;
+  children: JSX.Element | ((item: () => T) => JSX.Element) | ((item: T) => JSX.Element);
+}): JSX.Element;
 ```
 
 Here's an example of using the Show control flow:
@@ -16,6 +16,14 @@ Here's an example of using the Show control flow:
 ```tsx
 <Show when={state.count > 0} fallback={<div>Loading...</div>}>
   <div>My Content</div>
+</Show>
+```
+
+Show can also be used with a callback that returns a null asserted accessor. Remember to only use this accessor when the condition is true or it will throw.
+
+```tsx
+<Show when={state.user} fallback={<div>Loading...</div>}>
+  {(user) => <div>{user().firstName}</div>}
 </Show>
 ```
 

--- a/content/references/api-reference/lifecycles/onError.mdx
+++ b/content/references/api-reference/lifecycles/onError.mdx
@@ -1,1 +1,15 @@
+import {Aside} from '~/components/configurable/Aside'
+
 <Title>onError</Title>
+
+<Aside>
+Deprecated for `catchError` in v1.7
+</Aside>
+
+```ts
+import { onError } from "solid-js";
+
+function onError(fn: (err: any) => void): void;
+````
+
+Registers an error handler method that executes when child scope errors. Only the nearest scope error handlers execute. Rethrow to trigger up the line.

--- a/content/references/api-reference/reactive-utilities/catchError.mdx
+++ b/content/references/api-reference/reactive-utilities/catchError.mdx
@@ -1,0 +1,15 @@
+import {Aside} from '~/components/configurable/Aside'
+
+<Title>catchError</Title>
+
+<Aside>
+**New in v1.7.0**
+</Aside>
+
+```ts
+import { catchError } from "solid-js";
+
+function catchError<T>(tryFn: () => T, onError: (err: any) => void): T;
+```
+
+Wraps a `tryFn` with an error handler that fires if an error occurs below that point. Only the nearest scope error handlers execute. Rethrow to trigger up the line.

--- a/src/NAV_SECTIONS.ts
+++ b/src/NAV_SECTIONS.ts
@@ -120,7 +120,7 @@ export const REFERENCE_SECTIONS: SECTIONS = {
             link: "/references/api-reference/lifecycles/onCleanup",
           },
           {
-            name: "onError",
+            name: "onError (Deprecated)",
             link: "/references/api-reference/lifecycles/onError",
           },
         ],
@@ -183,6 +183,10 @@ export const REFERENCE_SECTIONS: SECTIONS = {
           {
             name: "indexArray",
             link: "/references/api-reference/reactive-utilities/indexArray",
+          },
+          {
+            name: "catchError",
+            link: "/references/api-reference/reactive-utilities/catchError",
           },
         ],
       },


### PR DESCRIPTION
Reflection of https://github.com/solidjs/solid-docs/pull/247 

I was not sure `onError()` in lifecycle section shoud be moved to reactive utils section. 🤔 