### PR TITLE
Fixed duplicate copy button issue

### DIFF
--- a/src/md.tsx
+++ b/src/md.tsx
@@ -152,10 +152,7 @@ export default {
         {...mergeProps(props, {
           get class() {
             return (
-              "relative " +
-              props.className +
-              " " +
-              (props.bad ? "border-red-400 border-1" : "")
+              props.className + (props.bad ? " border-red-400 border-1" : "")
             );
           },
           get className() {
@@ -164,7 +161,7 @@ export default {
         })}
         ref={ref}
       >
-        {props.children}
+        <div class="overflow-x-auto">{props.children}</div>
         <CopyButton parentRef={ref} />
       </pre>
     );

--- a/src/md.tsx
+++ b/src/md.tsx
@@ -148,31 +148,25 @@ export default {
     let ref: HTMLPreElement;
 
     return (
-      <div class="relative">
-        {/* <Show when={props.filename?.length > 5}>
-        <span {...props} class="h-4 p-1">
-          {props.filename}
-        </span>
-      </Show> */}
-        <pre
-          {...mergeProps(props, {
-            get class() {
-              return (
-                props.className +
-                " " +
-                (props.bad ? "border-red-400 border-1" : "")
-              );
-            },
-            get className() {
-              return undefined;
-            },
-          })}
-          ref={ref}
-        >
-          {props.children}
-        </pre>
+      <pre
+        {...mergeProps(props, {
+          get class() {
+            return (
+              "relative " +
+              props.className +
+              " " +
+              (props.bad ? "border-red-400 border-1" : "")
+            );
+          },
+          get className() {
+            return undefined;
+          },
+        })}
+        ref={ref}
+      >
+        {props.children}
         <CopyButton parentRef={ref} />
-      </div>
+      </pre>
     );
   },
   table: (props) => (


### PR DESCRIPTION
The copy button is duplicated for the light and dark themes, but the copy button was not inside the `<pre>` element which is what has the theme class applied to hide each theme version when it's not needed. 

![image](https://github.com/solidjs/solid-docs-next/assets/25469167/1cb92ce5-2aed-45cd-a644-679089c28122)


![Image 2023-06-24 at 1 31 08 AM](https://github.com/solidjs/solid-docs-next/assets/25469167/5fd180d9-d4d6-4afb-aeff-2ba9653dd40f)
