### PR TITLE
fix(nav): update dark:peer-checked to use thicker border-width

### DIFF
--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -8,10 +8,9 @@ import IconSvelte from "~icons/vscode-icons/file-type-svelte";
 import IconAngular from "~icons/vscode-icons/file-type-angular";
 import IconNone from "~icons/heroicons-outline/ban";
 
-
 interface PreferencesProps {
-  id: string,
-  isForContent?: boolean
+  id: string;
+  isForContent?: boolean;
 }
 
 export const Preferences = (props: PreferencesProps) => {
@@ -95,7 +94,7 @@ interface RadioButtonProps<T extends string> {
 
 const RadioButton = <T extends string>(props: RadioButtonProps<T>) => {
   return (
-    <div class="border border-solid-lightitem dark:border-solid-darkitem peer-checked:(bg-solid-light border-solid-accent) dark:peer-checked:bg-solid-dark text-sm rounded flex items-center gap-2 p-2 peer-focus-visible:outline peer-focus-visible:outline-offset-2 peer-focus-visible:outline-blue-600">
+    <div class="border border-solid-lightitem dark:border-solid-darkitem peer-checked:(bg-solid-light border-solid-accent) dark:peer-checked:(bg-solid-dark border-2) text-sm rounded flex items-center gap-2 p-2 peer-focus-visible:outline peer-focus-visible:outline-offset-2 peer-focus-visible:outline-blue-600">
       {props.icon}
       {props.label}
     </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
In dark mode, the Preferences form is not accessible for people who are red/green colorblind.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates the border width to be thicker when `dark:peer-checked` which fixes the issue.

## Other information
Dark mode updated to use thicker borders to be just as accessible as light theme:
![Screenshot 2023-07-01 at 12 09 45 PM](https://github.com/solidjs/solid-docs-next/assets/4819738/e4d19569-69d9-49eb-ab2c-c4f64d404a57)

Light mode, no change because it's accessible:
![Screenshot 2023-07-01 at 12 10 39 PM](https://github.com/solidjs/solid-docs-next/assets/4819738/47592744-cec6-4b83-9099-43360cf0ee3e)

I would recommend light mode use the same thickness and probably use a slightly darker border for the non-checked states though.