### PR TITLE
docs (createSiganl): fix the flaw in the example code

### DIFF
--- a/content/references/api-reference/basic-reactivity/createSignal.mdx
+++ b/content/references/api-reference/basic-reactivity/createSignal.mdx
@@ -101,7 +101,7 @@ const [depend, rerun] = createSignal(undefined, { equals: false });
 
 // define equality based on string length:
 const [myString, setMyString] = createSignal("string", {
-  equals: (newVal, oldVal) => newVal.length === oldVal.length,
+  equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("string"); // considered equal to the last value and won't cause updates


### PR DESCRIPTION
## Description of Problem
The following example code in this page's documentation is **miswritten**. 
According to the definition of `equals`, the first formal parameter should be `oldVal` and the second formal parameter should be `newVal`.

```js
// ...
const [myString, setMyString] = createSignal("string", {
  equals: (newVal, oldVal) => newVal.length === oldVal.length
});
// ...
```

## Proposed Solution
```js
// ...
const [myString, setMyString] = createSignal("string", {
  equals: (oldVal, newVal) => newVal.length === oldVal.length
});
// ...
```
## Other Info
This modification has also been synchronized to the old documentation, [look here](https://github.com/solidjs/solid-docs/pull/265).