### PR TITLE
docs: missing export on beginner tutorial

### DIFF
--- a/content/guides/tutorials/getting-started-with-solid/snippets/HelloWorld.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/HelloWorld.mdx
@@ -1,5 +1,5 @@
 ```tsx
-function HelloWorld() {
+export function HelloWorld() {
   return <div>Hello World!</div>;
 }
 ```


### PR DESCRIPTION
an export was missing causing the copy paste code to not run correctly