### PR TITLE
Fixed incorrect "error" property reference in createResource docs

### DIFF
--- a/content/references/api-reference/basic-reactivity/createResource.mdx
+++ b/content/references/api-reference/basic-reactivity/createResource.mdx
@@ -140,7 +140,7 @@ const [user] = createResource(() => params.id, fetchUser, {
 
 #### v1.5.0
 
-1. We've added a new state field which covers a more detailed view of the Resource state beyond `loading` and `error`. You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refreshing`, or `error`.
+1. We've added a new state field which covers a more detailed view of the Resource state beyond `loading` and `error`. You can now check whether a Resource is `unresolved`, `pending`, `ready`, `refreshing`, or `errored`.
 
 | State        | Value resolved | Loading | Has error |
 | ------------ | -------------- | ------- | --------- |
@@ -148,7 +148,7 @@ const [user] = createResource(() => params.id, fetchUser, {
 | `pending`    | No             | Yes     | No        |
 | `ready`      | Yes            | No      | No        |
 | `refreshing` | Yes            | Yes     | No        |
-| `error`      | No             | No      | Yes       |
+| `errored`    | No             | No      | Yes       |
 
 2. When server rendering resources especially when fetching when embedding Solid in other system that fetch before render, you might want to initiate the resource with this prefetched value instead of fetching again and having the resource serialize it in it's own state. You can use the new `ssrLoadFrom` option for this. Instead of using the default `server` value, you can pass `initial` and the resource will use `initialValue` as if it were the result of the first fetch for both SSR and hydration.
 


### PR DESCRIPTION
Related question: Are the legacy properties on a resource (loading, error) going to be deprecated at some point, or are they sticking around?