### PR TITLE
Fix typo in building-ui-with-components.mdx

### DIFF
--- a/content/guides/tutorials/getting-started-with-solid/building-ui-with-components.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/building-ui-with-components.mdx
@@ -281,7 +281,7 @@ See how this plays out in our project in the `index.html` file, which creates th
   js={[
     { name: "src/HelloWorld.jsx", component: HelloWorld2 },
     { name: "src/App.jsx", component: App },
-    { name: "src/index.tsx", component: IndexJS, default: true },
+    { name: "src/index.jsx", component: IndexJS, default: true },
     { name: "index.html", component: IndexHTML },
   ]}
   ts={[


### PR DESCRIPTION
For js CodeTabs, index file is incorrectly given the tsx extension. It should be jsx.