### PR TITLE
Rename signal in storage example

### DIFF
--- a/content/guides/foundations/solid-primitives.mdx
+++ b/content/guides/foundations/solid-primitives.mdx
@@ -249,14 +249,14 @@ async function fetcherFunc(id: number) {
 }
 
 const [id, setId] = createSignal<number>(1);
-const [store, setStore] = createSignal<any>({});
+const [data, setData] = createSignal<any>({});
 
 const [user] = createResource(id, fetcherFunc, {
-  storage: (init: any) => [store, setStore],
+  storage: (init: any) => [data, setData],
 });
 ```
 
-Once the resource's data is resolved in the above code it will be automatically stored in the `store` signal.
+Once the resource's data is resolved in the above code it will be automatically stored in the `data` signal.
 
 If you want to use multiple signal values within a single resource, you can do so by creating a derived state with the `createMemo` primitive. You may be wondering why I'm using the `createMemo` primitive instead of just creating a standard derived state. That's because `createMemo` will aid in keeping your derived state reactive, whereas if you create a normal derived state, the derived state will not be updated if the state value changes. Here's how it might look in action.
 


### PR DESCRIPTION
This is probably not the best example about `storage`, as the default storage of a resource is already a signal, but calling the signal `store` will make it even more confusing.