### PR TITLE
Fixing typo of it's to its

### DIFF
--- a/content/guides/how-to-guides/routing-in-solid/solid-router.mdx
+++ b/content/guides/how-to-guides/routing-in-solid/solid-router.mdx
@@ -11,7 +11,7 @@ In modern web development a router is a software component that is responsible f
 
 Solid Router is a simple and easy to use universal router for Solid applications. It works both on the client and on the server. The routes are defined using a simple JSX syntax and can be nested. However, routes can also be passed as a configuration object.
 
-Solid Router has a lot of cool features and one of those is it's ability to support nested routing which allows it to change a particular part of a component instead of replacing it completely.
+Solid Router has a lot of cool features and one of those is its ability to support nested routing which allows it to change a particular part of a component instead of replacing it completely.
 
 It supports all of Solid's SSR methods and has Solid's transitions baked in, so use it freely with suspense, resources, and lazy components. Solid Router also allows you to define a data function that loads parallel to the routes ([render-as-you-fetch](https://epicreact.dev/render-as-you-fetch/)).
 
@@ -183,7 +183,7 @@ render(
 );
 ```
 
-Here's an example of how to make use of the `A` component and it's `activeClass` prop.
+Here's an example of how to make use of the `A` component and its `activeClass` prop.
 
 ```jsx
 import styles from "./App.css";


### PR DESCRIPTION
They should be "its" to show association, not "it's" (i.e. it is).