### PR TITLE
`startTransition()` only has 1 parameter

### DIFF
--- a/content/references/api-reference/reactive-utilities/useTransition.mdx
+++ b/content/references/api-reference/reactive-utilities/useTransition.mdx
@@ -16,5 +16,5 @@ const [isPending, start] = useTransition();
 isPending();
 
 // wrap in transition
-start(() => setSignal(newValue), () => /* transition is done */)
+start(() => setSignal(newValue)).then(() => /* transition is done */)
 ```


### PR DESCRIPTION
this simply corrects `start(() => setSignal(newValue), () => /* transition is done */)` in content/references/api-reference/reactive-utilities/useTransition.mdx to `start(() => setSignal(newValue)).then(() => /* transition is done */)`