### PR TITLE
Fix typo in Adding Interactivity with State

### DIFF
--- a/content/guides/tutorials/getting-started-with-solid/adding-interactivity-with-state.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/adding-interactivity-with-state.mdx
@@ -188,7 +188,7 @@ Behind the scenes, Solid's compiler creates effects based on our JSX. It sees th
  
 A driving philosophy of Solid is that, by treating everything as a signal or an effect, we can better reason about our application.
 
-## Revisting the bookshelf
+## Revisiting the bookshelf
 
 We now have the tools necessary to make our Bookshelf application interactive. As a refresher, here's the current state of the app with the following components:
 


### PR DESCRIPTION
Fixes a typo in https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/adding-interactivity-with-state