### PR TITLE
Link to Stackblitz starters opens in a new tab

### DIFF
--- a/content/guides/tutorials/getting-started-with-solid/installing-solid.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/installing-solid.mdx
@@ -9,7 +9,7 @@ You can work with Solid using a browser-based editor, or install it locally on y
 
 The easiest way to get started with Solid is to choose a browser-based option.
 
-- **StackBlitz Starters**: Stackblitz is a web-based development environment. You can choose from either the [JavaScript starter](https://stackblitz.com/github/solidjs/templates/tree/master/js) or the [TypeScript starter](https://stackblitz.com/github/solidjs/templates/tree/master/ts). These links will set up a full project environment for you, and everything will run directly in your browser.
+- **StackBlitz Starters**: Stackblitz is a web-based development environment. You can choose from either the <a href="https://stackblitz.com/github/solidjs/templates/tree/master/js" target="_blank">JavaScript starter</a> or the <a href="https://stackblitz.com/github/solidjs/templates/tree/master/ts" target="_blank">TypeScript starter</a>. These links will set up a full project environment for you, and everything will run directly in your browser.
 
 ## In your local environment
 


### PR DESCRIPTION
I think it makes sense to have the links to the starters open in a new tab by default; users will be going through the tutorials and want to open up the start alongside it. Personally, I expected a new tab to be the default behavior and was surprised when it wasn't, which is why I'm proposing the change.