### PR TITLE
update signal getter names from count to getCount, etc.

### DIFF
--- a/content/guides/foundations/solid-primitives.mdx
+++ b/content/guides/foundations/solid-primitives.mdx
@@ -33,7 +33,7 @@ We will be focusing on the most used primitives, `createSignal`, `createMemo`, `
 ```js
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 ```
 
 `createSignal` doesn't need to be used within a component. It can be used anywhere in your app. Whether it's in a component, a function or even outside of a component or function.
@@ -41,28 +41,28 @@ const [count, setCount] = createSignal(0);
 ```js
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 function increment() {
-  setCount(count() + 1);
+  setCount(getCount() + 1);
 }
 
 function decrement() {
-  setCount(count() - 1);
+  setCount(getCount() - 1);
 }
 
 function Counter() {
   return (
     <div>
       <button onClick={decrement}>-</button>
-      <span>{count()}</span>
+      <span>{getCount()}</span>
       <button onClick={increment}>+</button>
     </div>
   );
 }
 ```
 
-In the example above we have a `count` state variable that is used to keep track of the current count. We have two functions, `increment` and `decrement` that are used to update the `count` state variable. We also have a component, `Counter` that uses the `count` state variable to display the current count.
+In the example above we have a `getCount` function that is used to keep track of the current count. We have two functions, `increment` and `decrement` that are used to update the `count` state variable. We also have a component, `Counter` that uses the `getCount` function to display the current count.
 
 As you've noticed in the example above, we are using `createSignal` outside of a component. This is perfectly fine, it is even possible to import your signal from another file and have it still behave reactively. You can use `createSignal` anywhere in your app since in Solid components do not own their state. In this way solid has state management built in and there is no need for Redux or other state management libraries unless you would like to make use of features specific to them.
 
@@ -103,35 +103,35 @@ As you've noticed in the example above, we are using `createSignal` outside of a
 ```js
 import { createSignal, createMemo } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
-const double = createMemo(() => count() * 2);
+const double = createMemo(() => getCount() * 2);
 ```
 
-In the example above we have a `count` state variable that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.
+In the example above we have a `getCount` function that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.
 
 Here's a quick example of how you can make use of `createMemo` to create a memoized derived state and make use of it in a component.
 
 ```js
 import { createMemo } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
-const double = createMemo(() => count() * 2);
+const double = createMemo(() => getCount() * 2);
 
 function Counter() {
   return (
     <div>
-      <button onClick={() => setCount(count() - 1)}>-</button>
-      <span>This is the base value : {count()}</span>
+      <button onClick={() => setCount(getCount() - 1)}>-</button>
+      <span>This is the base value : {getCount()}</span>
       <span>This is the doubled value : {double()}</span>
-      <button onClick={() => setCount(count() + 1)}>+</button>
+      <button onClick={() => setCount(getCount() + 1)}>+</button>
     </div>
   );
 }
 ```
 
-In the example above we have a `count` state variable that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.
+In the example above we have a `getCount` function that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.
 
 Under the hood `createMemo` uses `createComputed` to create a computed value. More on the `createComputed` primitive in the reference section.
 
@@ -158,18 +158,18 @@ Under the hood `createMemo` uses `createComputed` to create a computed value. Mo
 ```js
 import { createSignal, createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 createEffect(() => {
-  console.log("Count has been updated:", count());
+  console.log("Count has been updated:", getCount());
 });
 
 function Counter() {
   return (
     <div>
-      <button onClick={() => setCount(count() - 1)}>-</button>
-      <span>{count()}</span>
-      <button onClick={() => setCount(count() + 1)}>+</button>
+      <button onClick={() => setCount(getCount() - 1)}>-</button>
+      <span>{getCount()}</span>
+      <button onClick={() => setCount(getCount() + 1)}>+</button>
     </div>
   );
 }
@@ -212,8 +212,6 @@ async function fetchUser(id) {
 }
 
 function User({ id }) {
-  const [id, setId] = createSignal(1);
-
   const [user] = createResource(id, fetchUser);
 
   return (
@@ -248,11 +246,8 @@ async function fetcherFunc(id: number) {
   return await response.json();
 }
 
-const [id, setId] = createSignal<number>(1);
-const [data, setData] = createSignal<any>({});
-
 const [user] = createResource(id, fetcherFunc, {
-  storage: (init: any) => [data, setData],
+  storage: (init: any) => [getData, setData],
 });
 ```
 
@@ -271,11 +266,11 @@ async function fetcherFunc(info: { id: number; name: string }) {
   return await response.json();
 }
 
-const [id, setId] = createSignal<number>(1);
-const [name, setName] = createSignal<string>("");
+const [getId, setId] = createSignal<number>(1);
+const [getName, setName] = createSignal<string>("");
 
 // the derived state made using createMemo
-const derivedState = createMemo(() => ({ id: id(), name: name() }));
+const derivedState = createMemo(() => ({ id: getId(), name: getName() }));
 
 const [posts] = createResource(derivedState, fetcherFunc);
 ```

--- a/content/guides/foundations/thinking-solid.mdx
+++ b/content/guides/foundations/thinking-solid.mdx
@@ -70,16 +70,16 @@ Solid does this through the implementation of it's primitives. Examples of these
 Let's take a look at an example of what we mean by Read/Write Segregation.
 
 ```js
-const [name, setName] = createSignal("");
+const [getName, setName] = createSignal("");
 
-const valueOfName = name(); // 👈 getting
+const valueOfName = getName(); // 👈 getting
 
 function setValueOfName(text) {
   setName(text); // 👈 setting
 }
 ```
 
-In the above code snippet we're making use of one of Solids primitives, `createSignal`. In short, invoking this primitive creates a reactive value; and the two things returned from calling this primitive are the getter and the setter. Take note that `name` (the getter) is separated from `setName` (the setter). This is just one of the ways Solid segregates things.
+In the above code snippet we're making use of one of Solids primitives, `createSignal`. In short, invoking this primitive creates a reactive value; and the two things returned from calling this primitive are the getter and the setter. Take note that `getName` (the getter) is separated from `setName` (the setter). This is just one of the ways Solid segregates things.
 
 ## 4. Simple Is Better Than Easy
 

--- a/content/guides/foundations/typescript-for-solid.mdx
+++ b/content/guides/foundations/typescript-for-solid.mdx
@@ -69,7 +69,7 @@ Here, we explore the resulting types when using a few core primitives.
 signal. For example:
 
 ```ts
-const [count, setCount] = createSignal<number>();
+const [getCount, setCount] = createSignal<number>();
 ```
 
 The above `createSignal` has the return type `Signal<number>`, corresponding to
@@ -90,7 +90,7 @@ type Signal<T> = [get: Accessor<T>, set: Setter<T>];
   [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)
 </Aside>
 
-In this case, the signal getter `count` has type
+In this case, the signal getter `getCount` has type
 `Accessor<number | undefined>`. `Accessor<T>` is a type definition
 provided by Solid, in this case equivalent to `() => number | undefined`.
 The `| undefined` gets added in this example because we did not provide a
@@ -120,13 +120,13 @@ We can avoid having to explicitly provide the type of the signal when calling
 a default value to `createSignal`:
 
 ```ts
-const [count, setCount] = createSignal(0);
-const [name, setName] = createSignal("");
+const [getCount, setCount] = createSignal(0);
+const [getName, setName] = createSignal("");
 ```
 
 In this case, TypeScript infers that the signal types are `number` and `string`
-respectively. Thus, for example, `count` obtains type `Accessor<number>`
-and `name` obtains type `Accessor<string>` (without `| undefined`).
+respectively. Thus, for example, `getCount` obtains type `Accessor<number>`
+and `getName` obtains type `Accessor<string>` (without `| undefined`).
 
 ### Context
 
@@ -167,10 +167,10 @@ type helper, and use that to type the context:
 
 ```ts
 export const makeCountNameContext = (initialCount = 0, initialName = "") => {
-  const [count, setCount] = createSignal(initialCount);
-  const [name, setName] = createSignal(initialName);
+  const [getCount, setCount] = createSignal(initialCount);
+  const [getName, setName] = createSignal(initialName);
   return [
-    { count, name },
+    { getCount, getName },
     { setCount, setName },
   ] as const;
   // `as const` forces tuple type inference
@@ -185,7 +185,7 @@ In this example, `CountNameContextType` corresponds to the return value of
 
 ```ts
 [
-  {readonly count: Accessor<number>, readonly name: Accessor<string>},
+  {readonly getCount: Accessor<number>, readonly getName: Accessor<string>},
   {readonly setCount: Setter<number>, readonly setName: Setter<string>}
 ]
 ```
@@ -220,15 +220,15 @@ Here are some examples:
 
 ```tsx
 const Counter: Component = () => {
-  const [count, setCount] = createSignal(0);
-  return <button onClick={() => setCount((c) => c + 1)}>{count()}</button>;
+  const [getCount, setCount] = createSignal(0);
+  return <button onClick={() => setCount((c) => c + 1)}>{getCount()}</button>;
 };
 <Counter />; // good
 <Counter initial={5} />; // type error: no initial prop
 <Counter>hi</Counter>; // type error: no children prop
 const InitCounter: Component<{ initial: number }> = (props) => {
-  const [count, setCount] = createSignal(props.initial);
-  return <button onClick={() => setCount((c) => c + 1)}>{count()}</button>;
+  const [getCount, setCount] = createSignal(props.initial);
+  return <button onClick={() => setCount((c) => c + 1)}>{getCount()}</button>;
 };
 <InitCounter initial={5} />; // good
 ```
@@ -247,10 +247,10 @@ type ParentComponent<P = {}> = Component<ParentProps<P>>;
 //const CustomCounter: Component<{children?: JSX.Element}> = ...
 //function CustomCounter(props: ParentProps): JSX.Element { ...
 const CustomCounter: ParentComponent = (props) => {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
   return (
     <button onClick={() => setCount((c) => c + 1)}>
-      {count()}
+      {getCount()}
       {props.children}
     </button>
   );
@@ -259,10 +259,10 @@ const CustomCounter: ParentComponent = (props) => {
 //const CustomInitCounter: Component<{initial: number, children?: JSX.Element}> = ...
 //function CustomInitCounter(props: ParentProps<{initial: number}>): JSX.Element { ...
 const CustomInitCounter: ParentComponent<{ initial: number }> = (props) => {
-  const [count, setCount] = createSignal(props.initial);
+  const [getCount, setCount] = createSignal(props.initial);
   return (
     <button onClick={() => setCount((c) => c + 1)}>
-      {count()}
+      {getCount()}
       {props.children}
     </button>
   );
@@ -457,23 +457,23 @@ A common pattern is to use
 to display data only when that data is defined:
 
 ```tsx
-const [name, setName] = createSignal<string>();
-return <Show when={name()}>Hello {name().replace(/\s+/g, "\xa0")}!</Show>;
+const [getName, setName] = createSignal<string>();
+return <Show when={getName()}>Hello {getName().replace(/\s+/g, "\xa0")}!</Show>;
 ```
 
-In this case, TypeScript can't determine that the two calls to `name()` will
+In this case, TypeScript can't determine that the two calls to `getName()` will
 return the same value, and that the second call will happen only if the first
-call returned a truthy value. Thus it will complain that `name()` might be
+call returned a truthy value. Thus it will complain that `getName()` might be
 `undefined` when trying to call `.replace()`.
 
 Here are two workarounds for this issue:
 
-1. You can manually assert that `name()` will be non-null in the second call
+1. You can manually assert that `getName()` will be non-null in the second call
    using TypeScript's
    [non-null assertion operator `!`](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-):
 
    ```tsx
-   return <Show when={name()}>Hello {name()!.replace(/\s+/g, "\xa0")}!</Show>;
+   return <Show when={getName()}>Hello {getName()!.replace(/\s+/g, "\xa0")}!</Show>;
    ```
 
 2. You can use the callback form of `<Show>`, which passes in the value of the
@@ -481,7 +481,7 @@ Here are two workarounds for this issue:
 
    ```tsx
    return (
-     <Show when={name()}>{(n) => <>Hello {n().replace(/\s+/g, "\xa0")}!</>}</Show>
+     <Show when={getName()}>{(n) => <>Hello {n().replace(/\s+/g, "\xa0")}!</>}</Show>
    );
    ```
 
@@ -572,8 +572,8 @@ declare module "solid-js" {
     }
   }
 }
-let [name, setName] = createSignal("");
-<input type="text" use:model={[name, setName]} />;
+let [getName, setName] = createSignal("");
+<input type="text" use:model={[getName, setName]} />;
 ```
 
 If you're importing a directive `d` from another file/module, and `d` is used only

--- a/content/guides/foundations/understanding-components.mdx
+++ b/content/guides/foundations/understanding-components.mdx
@@ -69,37 +69,37 @@ Here's an example of what all this means:
 
 ```jsx
 function MyComponent() {
-  const [count, setCount] = createSignal(0)
+  const [getCount, setCount] = createSignal(0)
 
   // This will only be run once and will not be re-run when the application state changes
-  console.log(count())
+  console.log(getCount())
 
   return (
     <div>
-      <p>Count: {count()}</p>
-      <button onClick={() => setCount(count() + 1)}>Increment</button>
+      <p>Count: {getCount()}</p>
+      <button onClick={() => setCount(getCount() + 1)}>Increment</button>
     </div>
   )
 }
 ```
 
-As you can see in the above code there's a `console.log(count())` statement. This will only be run once, and will not be re-run when the application state changes. This is because the function is only run once, and is used to setup everything that needs to be tracked by the reactive system.
+As you can see in the above code there's a `console.log(getCount())` statement. This will only be run once, and will not be re-run when the application state changes. This is because the function is only run once, and is used to setup everything that needs to be tracked by the reactive system.
 
-In order to make the `console.log(count())` statement run every time the count state changes, we need to use a `createEffect` primitive. This primitive will run the function every time the count state changes. Here's an example of how this can be done:
+In order to make the `console.log(getCount())` statement run every time the count state changes, we need to use a `createEffect` primitive. This primitive will run the function every time the count state changes. Here's an example of how this can be done:
 
 ```jsx
 function MyComponent() {
-  const [count, setCount] = createSignal(0)
+  const [getCount, setCount] = createSignal(0)
 
   // This will be run every time the count state changes
   createEffect(() => {
-    console.log(count())
+    console.log(getCount())
   })
 
   return (
     <div>
-      <p>Count: {count()}</p>
-      <button onClick={() => setCount(count() + 1)}>Increment</button>
+      <p>Count: {getCount()}</p>
+      <button onClick={() => setCount(getCount() + 1)}>Increment</button>
     </div>
   )
 }
@@ -111,16 +111,16 @@ Here is another example of how Solid components are different from React compone
 
 ```jsx
 function MyComponent() {
-  const [count, setCount] = createSignal(0)
+  const [getCount, setCount] = createSignal(0)
 
-  if(count() > 5) {
+  if(getCount() > 5) {
     return <div>Count limit reached</div>
   }
 
   return (
     <div>
-      <p>Count: {count()}</p>
-      <button onClick={() => setCount(count() + 1)}>Increment</button>
+      <p>Count: {getCount()}</p>
+      <button onClick={() => setCount(getCount() + 1)}>Increment</button>
     </div>
   )
 }
@@ -130,14 +130,14 @@ In the above example, the component will not return the `Count limit reached` di
 
 ```jsx
 function MyComponent() {
-  const [count, setCount] = createSignal(0)
+  const [getCount, setCount] = createSignal(0)
 
   return (
     <div>
-      {count() > 5 ? <div>Count limit reached</div> : 
+      {getCount() > 5 ? <div>Count limit reached</div> :
         <>
-          <p>Count: {count()}</p>
-          <button onClick={() => setCount(count() + 1)}>Increment</button>
+          <p>Count: {getCount()}</p>
+          <button onClick={() => setCount(getCount() + 1)}>Increment</button>
         </>
       }
     </div>
@@ -149,14 +149,14 @@ The above code will work as expected and will show the `Count limit reached` div
 
 ```jsx
 function MyComponent() {
-  const [count, setCount] = createSignal(0)
+  const [getCount, setCount] = createSignal(0)
 
   return (
     <div>
-      <Show when={count() > 5} fallback={
+      <Show when={getCount() > 5} fallback={
         <>
-          <p>Count: {count()}</p>
-          <button onClick={() => setCount(count() + 1)}>Increment</button>
+          <p>Count: {getCount()}</p>
+          <button onClick={() => setCount(getCount() + 1)}>Increment</button>
         </>
       }>
         <div>Count limit reached</div>
@@ -211,9 +211,9 @@ function MyComponent(props) {
   const name = props.name
 
   // This is a good practice and will update within the component when the prop value changes
-  const [name, setName] = createSignal(props.name) // createSignal is a Solid primitive. More on this in the next page 
+  const [getName, setName] = createSignal(props.name) // createSignal is a Solid primitive. More on this in the next page
 
-  return <div>Hello {name}</div>
+  return <div>Hello {getName()}</div>
 }
 ```
 

--- a/content/guides/how-to-guides/comparison/react.mdx
+++ b/content/guides/how-to-guides/comparison/react.mdx
@@ -64,11 +64,11 @@ the **function component will run only once** as it won't handle state/props upd
 import { createSignal } from "solid-js";
 
 const App = () => {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
   return (
     <>
-      <p>Count is: {count()}</p>
+      <p>Count is: {getCount()}</p>
       <button onClick={() => setCount((prevCount) => prevCount + 1)}>
         Increase count by 1
       </button>
@@ -103,12 +103,12 @@ and Solid's code will still work.
 ```jsx
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 const App = () => {
   return (
     <>
-      <p>Count is: {count()}</p>
+      <p>Count is: {getCount()}</p>
       <button onClick={() => setCount((prevCount) => prevCount + 1)}>
         Increase count by 1
       </button>
@@ -157,15 +157,15 @@ We can write similar code, but once again, the execution model is different
 import { createSignal } from "solid-js";
 
 const App = () => {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
-  if (count() > 5) {
+  if (getCount() > 5) {
     return <p>Count is too high!</p>;
   }
 
   return (
     <>
-      <p>Count is: {count()}</p>
+      <p>Count is: {getCount()}</p>
       <button onClick={() => setCount((prevCount) => prevCount + 1)}>
         Increase count by 1
       </button>
@@ -188,11 +188,11 @@ the DOM output as a result of state change. Solid provides a built-in component 
 import { createSignal, Show } from "solid-js";
 
 const App = () => {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
   const fallback = (
     <>
-      <p>Count is: {count()}</p>
+      <p>Count is: {getCount()}</p>
       <button onClick={() => setCount((prevCount) => prevCount + 1)}>
         Increase count by 1
       </button>
@@ -200,7 +200,7 @@ const App = () => {
   );
 
   return (
-    <Show when={count() > 5} fallback={fallback}>
+    <Show when={getCount() > 5} fallback={fallback}>
       <p>Count is too high!</p>
     </Show>
   );
@@ -239,7 +239,7 @@ While this will also work on Solid, the idiomatic way to render lists is by usin
 import { createSignal, For } from "solid-js";
 
 const App = () => {
-  const [todos] = createSignal([
+  const [getTodos] = createSignal([
     { id: "1", name: "Learn Solid" },
     { id: "2", name: "Learn Solid Start" },
   ]);
@@ -248,7 +248,7 @@ const App = () => {
     <>
       <h1>TO-DO</h1>
       <ul>
-        <For each={todos()}>{(todo) => <li>{todo.name}</li>}</For>
+        <For each={getTodos()}>{(todo) => <li>{todo.name}</li>}</For>
       </ul>
     </>
   );
@@ -313,7 +313,7 @@ const Todos = ({ todos }) => {
 };
 
 const App = () => {
-  const [todos, setTodos] = createSignal([
+  const [getTodos, setTodos] = createSignal([
     { id: "1", name: "Learn Solid" },
     { id: "2", name: "Learn Solid Start" },
   ]);
@@ -321,7 +321,7 @@ const App = () => {
   return (
     <>
       <h1>TO-DO</h1>
-      <Todos todos={todos()} />
+      <Todos todos={getTodos()} />
       <button
         onClick={() =>
           setTodos((prev) => [...prev, { id: "3", name: "Learn Qwik" }])
@@ -353,7 +353,7 @@ const Todos = (props) => {
 };
 
 const App = () => {
-  const [todos, setTodos] = createSignal([
+  const [getTodos, setTodos] = createSignal([
     { id: "1", name: "Learn Solid" },
     { id: "2", name: "Learn Solid Start" },
   ]);
@@ -361,7 +361,7 @@ const App = () => {
   return (
     <>
       <h1>TO-DO</h1>
-      <Todos todos={todos()} />
+      <Todos todos={getTodos()} />
       <button
         onClick={() =>
           setTodos((prev) => [...prev, { id: "3", name: "Learn Qwik" }])

--- a/content/guides/how-to-guides/comparison/vue.mdx
+++ b/content/guides/how-to-guides/comparison/vue.mdx
@@ -36,11 +36,11 @@ Solid on the other hand makes use of only one kind of component, the function co
 import { createSignal } from "solid-js";
 
 const App = () => {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
   return (
     <div>
       <button onclick={() => setCount((previousValue) => previousValue + 1)}>
-        You clicked me {count} times
+        You clicked me {getCount()} times
       </button>
     </div>
   );
@@ -84,9 +84,9 @@ function someFunc() {
 }
 
 // Solid
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 function someFunc() {
-  console.log(count()); // accessing
+  console.log(getCount()); // accessing
   setCount((prev) => prev + 1); // setting
 }
 ```
@@ -247,18 +247,18 @@ You can also make use of the `createSignal()` primitive, like so:
 //store.js
 import { createSignal } from "solid-js";
 
-export const [storeUsingSignal, setStoreUsingSignal] = createSignal(0);
+export const [getStoreUsingSignal, setStoreUsingSignal] = createSignal(0);
 ```
 
 ```jsx
 // Component A.jsx
-import { setStoreUsingSignal, storeUsingSignal } from "./store";
+import { getStoreUsingSignal, setStoreUsingSignal } from "./store";
 
 const ComponentA = () => {
-  const reactiveLocalValue = storeUsingSignal;
+  const reactiveLocalValue = getStoreUsingSignal;
   // This 👆 will behave reactively
 
-  const unreactiveLocalValue = storeUsingSignal();
+  const unreactiveLocalValue = getStoreUsingSignal();
   // This 👆 will not behave reactively
 
   return (
@@ -275,18 +275,18 @@ export default ComponentA;
 
 ```jsx
 // Component B.jsx
-import { storeUsingSignal } from "./store";
+import { getStoreUsingSignal } from "./store";
 
 const ComponentB = () => {
-  const reactiveLocalValue = storeUsingSignal;
+  const reactiveLocalValue = getStoreUsingSignal;
   // This 👆 will behave reactively
 
-  const unreactiveLocalValue = storeUsingSignal();
+  const unreactiveLocalValue = getStoreUsingSignal();
   // This 👆 will not behave reactively
 
   return (
     <div>
-      <h2>From B: {storeUsingSignal()}</h2>
+      <h2>From B: {getStoreUsingSignal()}</h2>
       <h2>From B: {reactiveLocalValue()}</h2>
     </div>
   );
@@ -372,12 +372,12 @@ const options = {
 };
 
 function App() {
-  const [selected, setSelected] = createSignal("red");
+  const [getSelected, setSelected] = createSignal("red");
 
   return (
     <>
       <select
-        value={selected()}
+        value={getSelected()}
         onInput={(e) => setSelected(e.currentTarget.value)}
       >
         {Object.keys(options).map((color) => (
@@ -385,7 +385,7 @@ function App() {
         ))}
       </select>
       {/* the Dynamic component 👇*/}
-      <Dynamic component={options[selected()]} />
+      <Dynamic component={options[getSelected()]} />
     </>
   );
 }

--- a/content/guides/how-to-guides/testing-in-solid/snippets/jest-counter-js.mdx
+++ b/content/guides/how-to-guides/testing-in-solid/snippets/jest-counter-js.mdx
@@ -2,12 +2,12 @@
 import { createSignal } from "solid-js";
 
 export function Counter() {
-  const [count, setCount] = createSignal(1);
-  const increment = () => setCount(count() + 1);
+  const [getCount, setCount] = createSignal(1);
+  const increment = () => setCount(getCount() + 1);
 
   return (
     <button type="button" onClick={increment}>
-      {count()}
+      {getCount()}
     </button>
   );
 }

--- a/content/guides/how-to-guides/testing-in-solid/snippets/jest-counter-ts.mdx
+++ b/content/guides/how-to-guides/testing-in-solid/snippets/jest-counter-ts.mdx
@@ -2,12 +2,12 @@
 import { createSignal, type VoidComponent } from "solid-js";
 
 export const Counter: VoidComponent = () => {
-  const [count, setCount] = createSignal(1);
-  const increment = () => setCount(count() + 1);
+  const [getCount, setCount] = createSignal(1);
+  const increment = () => setCount(getCount() + 1);
 
   return (
     <button type="button" onClick={increment}>
-      {count().toString()}
+      {getCount().toString()}
     </button>
   );
 }

--- a/content/guides/how-to-guides/testing-in-solid/snippets/jest-lorem-test-js.mdx
+++ b/content/guides/how-to-guides/testing-in-solid/snippets/jest-lorem-test-js.mdx
@@ -4,8 +4,8 @@ import { renderHook } from "@solidjs/testing-library";
 import { createLorem } from "createLorem";
 
 test("it shows the right amount of words", () => {
-  const [words, setWords] = createSignal(3);
-  const { result } = renderHook(createLorem, [words]);
+  const [getWords, setWords] = createSignal(3);
+  const { result } = renderHook(createLorem, [getWords]);
   expect(result()).toBe("Lorem ipsum dolor");
   setWords(2);
   expect(result()).toBe("Lorem ipsum");

--- a/content/guides/how-to-guides/testing-in-solid/snippets/jest-lorem-test-ts.mdx
+++ b/content/guides/how-to-guides/testing-in-solid/snippets/jest-lorem-test-ts.mdx
@@ -4,8 +4,8 @@ import { renderHook } from "@solidjs/testing-library";
 import { createLorem } from "createLorem";
 
 test("it shows the right amount of words", () => {
-  const [words, setWords] = createSignal(3);
-  const { result } = renderHook(createLorem, [words]);
+  const [getWords, setWords] = createSignal(3);
+  const { result } = renderHook(createLorem, [getWords]);
   expect(result()).toBe("Lorem ipsum dolor");
   setWords(2);
   expect(result()).toBe("Lorem ipsum");

--- a/content/guides/how-to-guides/testing-in-solid/vitest.mdx
+++ b/content/guides/how-to-guides/testing-in-solid/vitest.mdx
@@ -124,11 +124,11 @@ Let's take a simple click counter component:
 import { createSignal, Component } from "solid-js";
 
 export const Counter: Component = () => {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
   return (
     <div role="button" onClick={() => setCount((c) => c + 1)}>
-      Count: {count()}
+      Count: {getCount()}
     </div>
   );
 };

--- a/content/guides/tutorials/getting-started-with-solid/adding-interactivity-with-state.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/adding-interactivity-with-state.mdx
@@ -47,21 +47,21 @@ In Solid, the most basic way to manage state in our application is to use a _sig
 ```tsx
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 ```
 
-There's a lot going on here: first, we call `createSignal` with the initial value of state. In this case, our `count` is going to start at `0`. The `createSignal` function returns a two-element array and we use JavaScript _destructuring assignment_ to unpack this array. In this case, we assign the first element to a variable called `count` and the second element to a variable called `setCount`.
+There's a lot going on here: first, we call `createSignal` with the initial value of state. In this case, our `count` is going to start at `0`. The `createSignal` function returns a two-element array and we use JavaScript _destructuring assignment_ to unpack this array. In this case, we assign the first element to a variable called `getCount` and the second element to a variable called `setCount`.
 
-The first element, `count`, is an _accessor_ function (also referred to as a _getter_) that returns the current value of state.
+The first element, `getCount`, is an _accessor_ function (also referred to as a _getter_) that returns the current value of state.
 
 It's important to note that this is a _function that gets the current value_, rather than the value itself. Along the way, this function call tells Solid to take note that we've accessed the signal here.
 
 ```tsx
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
-console.log(count()); // 0
+console.log(getCount()); // 0
 ```
 
 <FrameworkAside framework="svelte">
@@ -99,16 +99,16 @@ While this might seem like pure mental overhead, there are two main benefits of 
 2. It doesn't require any additional logic (like [`runOutsideAngular`](https://angular.io/api/core/NgZone#runOutsideAngular)) to avoid change detection
 </FrameworkAside>
 
-The second element, `setCount`, is a _setter_ function. If we want to increment our `count`, we can pass `count() + 1` to `setCount`:
+The second element, `setCount`, is a _setter_ function. If we want to increment our `count`, we can pass `getCount() + 1` to `setCount`:
 
 ```tsx
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
-setCount(count() + 1);
+setCount(getCount() + 1);
 
-console.log(count()); // 1
+console.log(getCount()); // 1
 ```
 
 Note that, in order to see our `count` value's new value, we added our `console.log` statement after we used `setCount`.
@@ -122,20 +122,20 @@ The ability to react to signal changes underpins Solid's reactive system. The mo
 ```tsx
 import { createSignal, createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 createEffect(() => {
-  console.log(count());
+  console.log(getCount());
 });
 
-setCount(count() + 1);
+setCount(getCount() + 1);
 ```
 
 To use `createEffect`, we pass it a function. When any signals used in that function update, the function will rerun.
 
 In this example, our effect depends on `count` and therefore the effect runs whenever `count` changes. Accordingly, we log `1` to the console just like before.
 
-Automatic effect dependency tracking is made possible by `count` being a function. When the `count` function is called inside an effect, that effect is registered as a listener for the signal. This is why it's so important that our signals are functions!
+Automatic effect dependency tracking is made possible by `getCount` being a function. When the `getCount` function is called inside an effect, that effect is registered as a listener for the signal. This is why it's so important that our signals are functions!
 
 <FrameworkAside framework="svelte">
   This is equivalent to `$: console.log(count)` in Svelte.
@@ -184,7 +184,7 @@ We see that, much like other variables, we can use signals inside our JSX code b
 
 And now we have a functioning counter! Notably, our text updates whenever our `count` is incremented. Does this remind you of an effect? Whenever the signal changes, the code that controls that part of the DOM reruns, similar to how the code in our effect reran whenever `count` changed.
 
-Behind the scenes, Solid's compiler creates effects based on our JSX. It sees that we're using `count()` in a specific part of the DOM, and it creates an effect that updates just that part of the DOM when the signal reruns.
+Behind the scenes, Solid's compiler creates effects based on our JSX. It sees that we're using `getCount()` in a specific part of the DOM, and it creates an effect that updates just that part of the DOM when the signal reruns.
  
 A driving philosophy of Solid is that, by treating everything as a signal or an effect, we can better reason about our application.
 

--- a/content/guides/tutorials/getting-started-with-solid/components/BasicBookshelf.tsx
+++ b/content/guides/tutorials/getting-started-with-solid/components/BasicBookshelf.tsx
@@ -18,14 +18,14 @@ interface IBookshelfProps {
 }
 
 export function BasicBookshelf(props: IBookshelfProps) {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <InteractiveExample>
       <div class="dark:bg-solid-darkbg border dark:border-solid-darkitem rounded-lg">
         <div class="p-4">
           <h2 class="text-2xl font-semibold mb-4">{props.name}'s Bookshelf</h2>
-          <BookList books={books()} />
+          <BookList books={getBooks()} />
         </div>
         <div class="border-t dark:border-solid-darkitem p-4">
           <AddBook setBooks={setBooks} />
@@ -70,11 +70,11 @@ interface IAddBookProps {
 const emptyBook: Book = { title: "", author: "" };
 
 function AddBook(props: IAddBookProps) {
-  const [newBook, setNewBook] = createSignal(emptyBook);
+  const [getNewBook, setNewBook] = createSignal(emptyBook);
 
   const addBook: JSX.EventHandler<HTMLButtonElement, MouseEvent> = (event) => {
     event.preventDefault();
-    props.setBooks((books) => [...books, newBook()]);
+    props.setBooks((books) => [...books, getNewBook()]);
     setNewBook(emptyBook);
   };
 
@@ -85,9 +85,9 @@ function AddBook(props: IAddBookProps) {
         <input
           id="title"
           class="ml-2 p-1 text-black border-1 border-black"
-          value={newBook().title}
+          value={getNewBook().title}
           onInput={(e) => {
-            setNewBook({ ...newBook(), title: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), title: e.currentTarget.value });
           }}
         />
       </div>
@@ -96,9 +96,9 @@ function AddBook(props: IAddBookProps) {
         <input
           id="author"
           class="ml-2 p-1 text-black border-1 border-black"
-          value={newBook().author}
+          value={getNewBook().author}
           onInput={(e) => {
-            setNewBook({ ...newBook(), author: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), author: e.currentTarget.value });
           }}
         />
       </div>

--- a/content/guides/tutorials/getting-started-with-solid/components/BasicBookshelfShow.tsx
+++ b/content/guides/tutorials/getting-started-with-solid/components/BasicBookshelfShow.tsx
@@ -16,17 +16,17 @@ interface IBookshelfProps {
 }
 
 export function BasicBookshelfShow(props: IBookshelfProps) {
-  const [books, setBooks] = createSignal(initialBooks);
-  const [showForm, setShowForm] = createSignal(false);
+  const [getBooks, setBooks] = createSignal(initialBooks);
+  const [getShowForm, setShowForm] = createSignal(false);
 
-  const toggleForm = () => setShowForm(!showForm());
+  const toggleForm = () => setShowForm(!getShowForm());
 
   return (
     <InteractiveExample>
       <h2 class="text-2xl mb-3">{props.name}'s Bookshelf</h2>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <Show
-        when={showForm()}
+        when={getShowForm()}
         fallback={
           <button
             class="px-3 py-2 rounded bg-solid-accent hover:bg-solid-accent/90 text-white"
@@ -81,11 +81,11 @@ interface IAddBookProps {
 const emptyBook: Book = { title: "", author: "" };
 
 function AddBook(props: IAddBookProps) {
-  const [newBook, setNewBook] = createSignal(emptyBook);
+  const [getNewBook, setNewBook] = createSignal(emptyBook);
 
   const addBook: JSX.EventHandler<HTMLButtonElement, MouseEvent> = (event) => {
     event.preventDefault();
-    props.setBooks((books) => [...books, newBook()]);
+    props.setBooks((books) => [...books, getNewBook()]);
     setNewBook(emptyBook);
   };
 
@@ -96,9 +96,9 @@ function AddBook(props: IAddBookProps) {
         <input
           id="title"
           class="ml-2 p-1 text-black border-1 border-black"
-          value={newBook().title}
+          value={getNewBook().title}
           onInput={(e) => {
-            setNewBook({ ...newBook(), title: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), title: e.currentTarget.value });
           }}
         />
       </div>
@@ -107,9 +107,9 @@ function AddBook(props: IAddBookProps) {
         <input
           id="author"
           class="ml-2 p-1 text-black border-1 border-black"
-          value={newBook().author}
+          value={getNewBook().author}
           onInput={(e) => {
-            setNewBook({ ...newBook(), author: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), author: e.currentTarget.value });
           }}
         />
       </div>

--- a/content/guides/tutorials/getting-started-with-solid/components/BasicCounter.tsx
+++ b/content/guides/tutorials/getting-started-with-solid/components/BasicCounter.tsx
@@ -3,16 +3,16 @@ import Button from "~/components/Button";
 import InteractiveExample from "~/components/configurable/interactiveExample";
 
 export function BasicCounter() {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
   const increment = () => {
-    setCount(count() + 1);
+    setCount(getCount() + 1);
   };
 
   return (
     <InteractiveExample>
       <div class="flex items-center gap-2">
-        Current count: {count()}
+        Current count: {getCount()}
         <Button
           type="button"
           onClick={increment}

--- a/content/guides/tutorials/getting-started-with-solid/components/FinishedBookshelf.tsx
+++ b/content/guides/tutorials/getting-started-with-solid/components/FinishedBookshelf.tsx
@@ -20,21 +20,21 @@ interface IBookshelfProps {
 }
 
 export function FinishedBookshelf(props: IBookshelfProps) {
-  const [books, setBooks] = createSignal(initialBooks);
-  const [showForm, setShowForm] = createSignal(false);
+  const [getBooks, setBooks] = createSignal(initialBooks);
+  const [getShowForm, setShowForm] = createSignal(false);
 
-  const toggleForm = () => setShowForm(!showForm());
+  const toggleForm = () => setShowForm(!getShowForm());
 
   return (
     <InteractiveExample>
       <div class="dark:bg-solid-darkbg border dark:border-solid-darkitem rounded-lg">
         <div class="p-4">
           <h2 class="text-2xl font-semibold mb-4">{props.name}'s Bookshelf</h2>
-          <BookList books={books()} />
+          <BookList books={getBooks()} />
         </div>
         <div class="border-t dark:border-solid-darkitem p-4">
           <Show
-            when={showForm()}
+            when={getShowForm()}
             fallback={
               <Button type="button" onClick={toggleForm}>
                 Add a book
@@ -96,10 +96,10 @@ async function searchBooks(query: string) {
 }
 
 function AddBook(props: IAddBookProps) {
-  const [input, setInput] = createSignal("");
-  const [query, setQuery] = createSignal("");
+  const [getInput, setInput] = createSignal("");
+  const [getQuery, setQuery] = createSignal("");
 
-  const [data] = createResource<Book[], string>(query, searchBooks);
+  const [data] = createResource<Book[], string>(getQuery, searchBooks);
 
   return (
     <>
@@ -107,7 +107,7 @@ function AddBook(props: IAddBookProps) {
         <SearchInput
           label="search books"
           id="title"
-          input={input()}
+          input={getInput()}
           onInput={(e) => {
             setInput(e.currentTarget.value);
           }}
@@ -117,7 +117,7 @@ function AddBook(props: IAddBookProps) {
           type="submit"
           onClick={(e) => {
             e.preventDefault();
-            setQuery(input());
+            setQuery(getInput());
           }}
         >
           Search

--- a/content/guides/tutorials/getting-started-with-solid/snippets/Counter1.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/Counter1.mdx
@@ -2,8 +2,8 @@
 import { createSignal } from "solid-js";
 
 function Counter() {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
-  return <div>Current count: {count()}</div>;
+  return <div>Current count: {getCount()}</div>;
 }
 ```

--- a/content/guides/tutorials/getting-started-with-solid/snippets/Counter2.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/Counter2.mdx
@@ -2,15 +2,15 @@
 import { createSignal } from "solid-js";
 
 function Counter() {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
   const increment = () => {
-    setCount(count() + 1);
+    setCount(getCount() + 1);
   };
 
   return (
     <div>
-      Current count: {count()}
+      Current count: {getCount()}
       <button onClick={increment}>Increment</button>
     </div>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook3js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook3js.mdx
@@ -4,11 +4,11 @@ import { createSignal } from "solid-js";
 const emptyBook = { title: "", author: "" };
 
 export function AddBook(props) {
-  const [newBook, setNewBook] = createSignal(emptyBook);
+  const [getNewBook, setNewBook] = createSignal(emptyBook);
 
   const addBook = (event) => {
     event.preventDefault();
-    props.setBooks((books) => [...books, newBook()]);
+    props.setBooks((books) => [...books, getNewBook()]);
     setNewBook(emptyBook);
   };
 
@@ -18,9 +18,9 @@ export function AddBook(props) {
         <label for="title">Book name</label>
         <input
           id="title"
-          value={newBook().title}
+          value={getNewBook().title}
           onInput={(e) => {
-            setNewBook({ ...newBook(), title: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), title: e.currentTarget.value });
           }}
         />
       </div>
@@ -28,9 +28,9 @@ export function AddBook(props) {
         <label for="author">Author</label>
         <input
           id="author"
-          value={newBook().author}
+          value={getNewBook().author}
           onInput={(e) => {
-            setNewBook({ ...newBook(), author: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), author: e.currentTarget.value });
           }}
         />
       </div>

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook3ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook3ts.mdx
@@ -9,11 +9,11 @@ export interface AddBookProps {
 const emptyBook: Book = { title: "", author: "" };
 
 export function AddBook(props: AddBookProps) {
-  const [newBook, setNewBook] = createSignal(emptyBook);
+  const [getNewBook, setNewBook] = createSignal(emptyBook);
 
   const addBook: JSX.EventHandler<HTMLButtonElement, MouseEvent> = (event) => {
     event.preventDefault();
-    props.setBooks((books) => [...books, newBook()]);
+    props.setBooks((books) => [...books, getNewBook()]);
     setNewBook(emptyBook);
   };
 
@@ -23,9 +23,9 @@ export function AddBook(props: AddBookProps) {
         <label for="title">Book name</label>
         <input
           id="title"
-          value={newBook().title}
+          value={getNewBook().title}
           onInput={(e) => {
-            setNewBook({ ...newBook(), title: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), title: e.currentTarget.value });
           }}
         />
       </div>
@@ -33,9 +33,9 @@ export function AddBook(props: AddBookProps) {
         <label for="author">Author</label>
         <input
           id="author"
-          value={newBook().author}
+          value={getNewBook().author}
           onInput={(e) => {
-            setNewBook({ ...newBook(), author: e.currentTarget.value });
+            setNewBook({ ...getNewBook(), author: e.currentTarget.value });
           }}
         />
       </div>

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook4js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook4js.mdx
@@ -2,8 +2,8 @@
 import { createSignal } from "solid-js";
 
 export function AddBook(props) {
-  const [input, setInput] = createSignal("");
-  const [query, setQuery] = createSignal("");
+  const [getInput, setInput] = createSignal("");
+  const [getQuery, setQuery] = createSignal("");
 
   return (
     <form>
@@ -11,7 +11,7 @@ export function AddBook(props) {
         <label for="title">Search books</label>
         <input
           id="title"
-          value={input()}
+          value={getInput()}
           onInput={(e) => {
             setInput(e.currentTarget.value);
           }}
@@ -21,7 +21,7 @@ export function AddBook(props) {
         type="submit"
         onClick={(e) => {
           e.preventDefault();
-          setQuery(input());
+          setQuery(getInput());
         }}
       >
         Search

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook4ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook4ts.mdx
@@ -7,8 +7,8 @@ export interface AddBookProps {
 }
 
 export function AddBook(props: AddBookProps) {
-  const [input, setInput] = createSignal("");
-  const [query, setQuery] = createSignal("");
+  const [getInput, setInput] = createSignal("");
+  const [getQuery, setQuery] = createSignal("");
 
   return (
     <form>
@@ -16,7 +16,7 @@ export function AddBook(props: AddBookProps) {
         <label for="title">Search books</label>
         <input
           id="title"
-          value={input()}
+          value={getInput()}
           onInput={(e) => {
             setInput(e.currentTarget.value);
           }}
@@ -26,7 +26,7 @@ export function AddBook(props: AddBookProps) {
         type="submit"
         onClick={(e) => {
           e.preventDefault();
-          setQuery(input());
+          setQuery(getInput());
         }}
       >
         Search

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook5js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook5js.mdx
@@ -3,10 +3,10 @@ import { createSignal, JSX, createResource, For, Show } from "solid-js";
 import { searchBooks } from "./searchBooks";
 
 export function AddBook(props) {
-  const [input, setInput] = createSignal("");
-  const [query, setQuery] = createSignal("");
+  const [getInput, setInput] = createSignal("");
+  const [getQuery, setQuery] = createSignal("");
 
-  const [data] = createResource(query, searchBooks);
+  const [data] = createResource(getQuery, searchBooks);
 
   return (
     <>
@@ -15,7 +15,7 @@ export function AddBook(props) {
           <label for="title">Search books</label>
           <input
             id="title"
-            value={input()}
+            value={getInput()}
             onInput={(e) => {
               setInput(e.currentTarget.value);
             }}
@@ -25,7 +25,7 @@ export function AddBook(props) {
           type="submit"
           onClick={(e) => {
             e.preventDefault();
-            setQuery(input());
+            setQuery(getInput());
           }}
         >
           Search

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook5ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/AddBook5ts.mdx
@@ -8,10 +8,10 @@ export interface AddBookProps {
 }
 
 export function AddBook(props: AddBookProps) {
-  const [input, setInput] = createSignal("");
-  const [query, setQuery] = createSignal("");
+  const [getInput, setInput] = createSignal("");
+  const [getQuery, setQuery] = createSignal("");
 
-  const [data] = createResource<Book[], string>(query, searchBooks);
+  const [data] = createResource<Book[], string>(getQuery, searchBooks);
 
   return (
     <>
@@ -20,7 +20,7 @@ export function AddBook(props: AddBookProps) {
           <label for="title">Search books</label>
           <input
             id="title"
-            value={input()}
+            value={getInput()}
             onInput={(e) => {
               setInput(e.currentTarget.value);
             }}
@@ -30,7 +30,7 @@ export function AddBook(props: AddBookProps) {
           type="submit"
           onClick={(e) => {
             e.preventDefault();
-            setQuery(input());
+            setQuery(getInput());
           }}
         >
           Search

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App3js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App3js.mdx
@@ -10,12 +10,12 @@ const initialBooks = [
 ];
 
 function Bookshelf(props) {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <div>
       <h1>{props.name}'s Bookshelf</h1>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <AddBook />
     </div>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App3ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App3ts.mdx
@@ -19,12 +19,12 @@ interface BookshelfProps {
 }
 
 function Bookshelf(props: BookshelfProps) {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <div>
       <h1>{props.name}'s Bookshelf</h1>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <AddBook />
     </div>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App4js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App4js.mdx
@@ -10,12 +10,12 @@ const initialBooks = [
 ];
 
 function Bookshelf(props) {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <div>
       <h1>{props.name}'s Bookshelf</h1>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <AddBook setBooks={setBooks} />
     </div>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App4ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App4ts.mdx
@@ -19,12 +19,12 @@ interface BookshelfProps {
 }
 
 function Bookshelf(props: BookshelfProps) {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <div>
       <h1>{props.name}'s Bookshelf</h1>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <AddBook setBooks={setBooks} />
     </div>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App5js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App5js.mdx
@@ -10,17 +10,17 @@ const initialBooks = [
 ];
 
 function Bookshelf(props) {
-  const [books, setBooks] = createSignal(initialBooks);
-  const [showForm, setShowForm] = createSignal(false);
+  const [getBooks, setBooks] = createSignal(initialBooks);
+  const [getShowForm, setShowForm] = createSignal(false);
 
-  const toggleForm = () => setShowForm(!showForm());
+  const toggleForm = () => setShowForm(!getShowForm());
 
   return (
     <div>
       <h1>{props.name}'s Bookshelf</h1>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <Show
-        when={showForm()}
+        when={getShowForm()}
         fallback={<button onClick={toggleForm}>Add a book</button>}
       >
         <AddBook setBooks={setBooks} />

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App5ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/App5ts.mdx
@@ -19,17 +19,17 @@ interface BookshelfProps {
 }
 
 function Bookshelf(props: BookshelfProps) {
-  const [books, setBooks] = createSignal(initialBooks);
-  const [showForm, setShowForm] = createSignal(false);
+  const [getBooks, setBooks] = createSignal(initialBooks);
+  const [getShowForm, setShowForm] = createSignal(false);
 
-  const toggleForm = () => setShowForm(!showForm());
+  const toggleForm = () => setShowForm(!getShowForm());
 
   return (
     <div>
       <h1>{props.name}'s Bookshelf</h1>
-      <BookList books={books()} />
+      <BookList books={getBooks()} />
       <Show
-        when={showForm()}
+        when={getShowForm()}
         fallback={<button onClick={toggleForm}>Add a book</button>}
       >
         <AddBook setBooks={setBooks} />

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList2js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList2js.mdx
@@ -8,17 +8,17 @@ const initialBooks = [
 ];
 
 export function BookList() {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <ul>
       <li>
-        {books()[0].title}{" "}
-        <span style={{ "font-style": "italic" }}>({books()[0].author})</span>
+        {getBooks()[0].title}{" "}
+        <span style={{ "font-style": "italic" }}>({getBooks()[0].author})</span>
       </li>
       <li>
-        {books()[1].title}{" "}
-        <span style={{ "font-style": "italic" }}>({books()[1].author})</span>
+        {getBooks()[1].title}{" "}
+        <span style={{ "font-style": "italic" }}>({getBooks()[1].author})</span>
       </li>
     </ul>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList2ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList2ts.mdx
@@ -13,17 +13,17 @@ const initialBooks: Book[] = [
 ];
 
 export function BookList() {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <ul>
       <li>
-        {books()[0].title}{" "}
-        <span style={{ "font-style": "italic" }}>({books()[0].author})</span>
+        {getBooks()[0].title}{" "}
+        <span style={{ "font-style": "italic" }}>({getBooks()[0].author})</span>
       </li>
       <li>
-        {books()[1].title}{" "}
-        <span style={{ "font-style": "italic" }}>({books()[1].author})</span>
+        {getBooks()[1].title}{" "}
+        <span style={{ "font-style": "italic" }}>({getBooks()[1].author})</span>
       </li>
     </ul>
   );

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList3js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList3js.mdx
@@ -8,11 +8,11 @@ const initialBooks = [
 ];
 
 export function BookList() {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <ul>
-      <For each={books()}>
+      <For each={getBooks()}>
         {(book) => {
           return (
             <li>

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList3ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList3ts.mdx
@@ -13,11 +13,11 @@ const initialBooks: Book[] = [
 ];
 
 export function BookList() {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
   return (
     <ul>
-      <For each={books()}>
+      <For each={getBooks()}>
         {(book) => {
           return (
             <li>

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList4js.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList4js.mdx
@@ -8,15 +8,15 @@ const initialBooks = [
 ];
 
 export function BookList() {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
-  const totalBooks = () => books().length;
+  const totalBooks = () => getBooks().length;
 
   return (
     <>
       <h2>My books ({totalBooks()})</h2>
       <ul>
-        <For each={books()}>
+        <For each={getBooks()}>
           {(book) => {
             return (
               <li>

--- a/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList4ts.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/bookshelf/BookList4ts.mdx
@@ -13,15 +13,15 @@ const initialBooks: Book[] = [
 ];
 
 export function BookList() {
-  const [books, setBooks] = createSignal(initialBooks);
+  const [getBooks, setBooks] = createSignal(initialBooks);
 
-  const totalBooks = () => books().length;
+  const totalBooks = () => getBooks().length;
 
   return (
     <>
       <h2>My books ({totalBooks()})</h2>
       <ul>
-        <For each={books()}>
+        <For each={getBooks()}>
           {(book) => {
             return (
               <li>

--- a/content/references/api-reference/basic-reactivity/createEffect.mdx
+++ b/content/references/api-reference/basic-reactivity/createEffect.mdx
@@ -7,10 +7,10 @@ function createEffect<T>(fn: (v: T) => T, value?: T): void;
 Effects are a general way to make arbitrary code ("side effects") run whenever dependencies change, e.g., to modify the DOM manually. `createEffect` creates a new computation that runs the given function in a tracking scope, thus automatically tracking its dependencies, and automatically reruns the function whenever the dependencies update. For example:
 
 ```ts
-const [a, setA] = createSignal(initialValue);
+const [getA, setA] = createSignal(initialValue);
 
 // effect that depends on signal `a`
-createEffect(() => doSideEffect(a()));
+createEffect(() => doSideEffect(getA()));
 ```
 
 The effect will run whenever `a` changes value.
@@ -20,12 +20,12 @@ The effect will also run once, immediately after it is created, to initialize th
 The effect callback can return a value, which will be passed as the `prev` argument to the next invocation of the effect. This is useful for memoizing values that are expensive to compute. For example:
 
 ```ts
-const [a, setA] = createSignal(initialValue);
+const [getA, setA] = createSignal(initialValue);
 
 // effect that depends on signal `a`
 createEffect((prevA) => {
   // do something with `a` and `prevA`
-  const sum = a() + b();
+  const sum = getA() + b();
   if (sum !== prevA) console.log("sum changed to", sum);
   return sum;
 }, 0);
@@ -38,10 +38,10 @@ The first execution of the effect function is not immediate; it's scheduled to r
 
 ```ts
 // assume this code is in a component function, so is part of a rendering phase
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 // this effect prints count at the beginning and when it changes
-createEffect(() => console.log("count =", count()));
+createEffect(() => console.log("count =", getCount()));
 // effect won't run yet
 console.log("hello");
 setCount(1); // effect still won't run yet

--- a/content/references/api-reference/basic-reactivity/createResource.mdx
+++ b/content/references/api-reference/basic-reactivity/createResource.mdx
@@ -102,10 +102,10 @@ refetch();
 It's also possible to pass multiple signals as the source, by constructing a derived signal:
 
 ```ts
-const [dataSignal, setDataSignal] = createSignal(1);
-const [moreData, setMoreData] = createSignal("string_data");
+const [getDataSignal, setDataSignal] = createSignal(1);
+const [getMoreData, setMoreData] = createSignal("string_data");
 const [data] = createResource(
-  () => [dataSignal(), moreData()] as const,
+  () => [getDataSignal(), getMoreData()] as const,
   ([dataVal, moreDataVal]) => {
     // Reruns when either signal updates
   }
@@ -117,7 +117,7 @@ Alternatively, these can be explicitly typed when passed to the fetcher:
 
 ```ts
 const [data] = createResource(
-  () => [dataSignal(), moreData()],
+  () => [getDataSignal(), getMoreData()],
   ([dataVal, moreDataVal]) => fetcher(dataVal as number, moreDataVal as string)
 );
 ```

--- a/content/references/api-reference/basic-reactivity/createSignal.mdx
+++ b/content/references/api-reference/basic-reactivity/createSignal.mdx
@@ -25,11 +25,11 @@ type Setter<T> = (v: T | ((prev?: T) => T)) => T;
 The Signal's value starts out equal to the passed first argument initialValue (or undefined if there are no arguments). The createSignal function returns a pair of functions as a two-element array: a getter (or accessor) and a setter. In typical use, you would destructure this array into a named Signal like so:
 
 ```ts
-const [count, setCount] = createSignal(0);
-const [ready, setReady] = createSignal(false);
+const [getCount, setCount] = createSignal(0);
+const [getReady, setReady] = createSignal(false);
 ```
 
-Calling the getter (e.g., `count()` or `ready()`) returns the current value of the Signal.
+Calling the getter (e.g., `getCount()` or `getReady()`) returns the current value of the Signal.
 
 Crucial to automatic dependency tracking, calling the getter within a tracking scope causes the calling function to depend on this Signal, so that function will rerun if the Signal gets updated.
 
@@ -39,14 +39,14 @@ Calling the setter (e.g., `setCount(nextCount)` or `setReady(nextReady)`) sets t
 // read signal's current value, and
 // depend on signal if in a tracking scope
 // (but nonreactive outside of a tracking scope):
-const currentCount = count();
+const currentCount = getCount();
 
 // or wrap any computation with a function,
 // and this function can be used in a tracking scope:
-const doubledCount = () => 2 * count();
+const doubledCount = () => 2 * getCount();
 
 // or build a tracking scope and depend on signal:
-const countDisplay = <div>{count()}</div>;
+const countDisplay = <div>{getCount()}</div>;
 
 // write signal by providing a value:
 setReady(true);
@@ -76,7 +76,7 @@ const newCount = setCount((prev) => prev + 1);
 The `equals` option can be used to customize the equality check used to determine whether the Signal's value has changed. By default, the equality check is a strict equality check (`===`). If you want to use a different equality check, you can pass a custom function as the `equals` option. The custom function will be called with the previous and next values of the Signal as arguments. If the function returns true, the Signal's value will not be updated and dependents will not rerun. If the function returns false, the Signal's value will be updated and dependents will rerun.
 
 ```ts
-const [count, setCount] = createSignal(0, {
+const [getCount, setCount] = createSignal(0, {
   equals: (prev, next) => prev === next,
 });
 ```
@@ -87,7 +87,7 @@ Here's are some examples of this option in use:
 // use { equals: false } to allow modifying object in-place;
 // normally this wouldn't be seen as an update because the
 // object has the same identity before and after change
-const [object, setObject] = createSignal({ count: 0 }, { equals: false });
+const [getObject, setObject] = createSignal({ count: 0 }, { equals: false });
 setObject((current) => {
   current.count += 1;
   current.updated = new Date();
@@ -95,12 +95,12 @@ setObject((current) => {
 });
 
 // use { equals: false } signal as trigger without value:
-const [depend, rerun] = createSignal(undefined, { equals: false });
-// now calling depend() in a tracking scope
+const [getDepend, rerun] = createSignal(undefined, { equals: false });
+// now calling getDepend() in a tracking scope
 // makes that scope rerun whenever rerun() gets called
 
 // define equality based on string length:
-const [myString, setMyString] = createSignal("string", {
+const [getMyString, setMyString] = createSignal("string", {
   equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
@@ -113,7 +113,7 @@ setMyString("stranger"); // considered different and will cause updates
 The `name` option can be used to give the Signal a name. This is useful for debugging. The name will be displayed in the devtools.
 
 ```ts
-const [count, setCount] = createSignal(0, { name: "count" });
+const [getCount, setCount] = createSignal(0, { name: "count" });
 ```
 
 ### `internal`
@@ -121,5 +121,5 @@ const [count, setCount] = createSignal(0, { name: "count" });
 The `internal` option can be used to hide the Signal from the devtools. This is useful for Signals that are used internally by a component and should not be exposed to the user.
 
 ```ts
-const [count, setCount] = createSignal(0, { internal: true });
+const [getCount, setCount] = createSignal(0, { internal: true });
 ```

--- a/content/references/api-reference/basic-reactivity/snippets/createSignalFuncForm2.mdx
+++ b/content/references/api-reference/basic-reactivity/snippets/createSignalFuncForm2.mdx
@@ -1,3 +1,3 @@
 ```ts 
-const [func, setFunc] = createSignal(myFunction);
+const [getFunc, setFunc] = createSignal(myFunction);
 ```

--- a/content/references/api-reference/control-flow/Index.mdx
+++ b/content/references/api-reference/control-flow/Index.mdx
@@ -19,8 +19,8 @@ function Index<T, U extends JSX.Element>(props: {
   children: (item: () => T, index: number) => U;
 }) {
   return () => {
-    const [items, setItems] = createSignal(props.each);
-    return props.each.map((_, i) => props.children(() => items()[i], i));
+    const [getItems, setItems] = createSignal(props.each);
+    return props.each.map((_, i) => props.children(() => getItems()[i], i));
   };
 }
 ```

--- a/content/references/api-reference/reactive-utilities/mapArray.mdx
+++ b/content/references/api-reference/reactive-utilities/mapArray.mdx
@@ -13,16 +13,16 @@ Underlying helper for the `<For>` control flow.
 
 ```ts
 const mapped = mapArray(source, (model) => {
-  const [name, setName] = createSignal(model.name);
-  const [description, setDescription] = createSignal(model.description);
+  const [getName, setName] = createSignal(model.name);
+  const [getDescription, setDescription] = createSignal(model.description);
 
   return {
     id: model.id,
     get name() {
-      return name();
+      return getName();
     },
     get description() {
-      return description();
+      return getDescription();
     },
     setName,
     setDescription,

--- a/content/references/api-reference/reactive-utilities/observable.mdx
+++ b/content/references/api-reference/reactive-utilities/observable.mdx
@@ -11,9 +11,9 @@ This method takes a signal and produces an Observable. You can consume it from a
 import { observable } from "solid-js";
 import { from } from "rxjs";
 
-const [s, set] = createSignal(0);
+const [getS, set] = createSignal(0);
 
-const obsv$ = from(observable(s));
+const obsv$ = from(observable(getS));
 
 obsv$.subscribe((v) => console.log(v));
 ```

--- a/content/references/api-reference/secondary-primitives/createReaction.mdx
+++ b/content/references/api-reference/secondary-primitives/createReaction.mdx
@@ -7,16 +7,16 @@ function createReaction(onInvalidate: () => void): (fn: () => void) => void;
 Sometimes it is useful to separate tracking from re-execution. This primitive registers a side effect that is run the first time the expression wrapped by the returned tracking function is notified of a change.
 
 ```ts 
-const [s, set] = createSignal("start");
+const [getS, setS] = createSignal("start");
 
 const track = createReaction(() => console.log("something"));
 
-// next time s changes run the reaction
-track(() => s());
+// next time getS() changes run the reaction
+track(() => getS());
 
-set("end"); // "something"
+setS("end"); // "something"
 
-set("final"); // no-op as reaction only runs on first update, need to call track again.
+setS("final"); // no-op as reaction only runs on first update, need to call track again.
 ```
 
 {/* TODO: Add code playground example */}

--- a/content/references/api-reference/secondary-primitives/createRenderEffect.mdx
+++ b/content/references/api-reference/secondary-primitives/createRenderEffect.mdx
@@ -12,10 +12,10 @@ Here is an example of the behavior. (Compare with the example in [`createEffect`
 
 ```ts
 // assume this code is in a component function, so is part of a rendering phase
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 // this effect prints count at the beginning and when it changes
-createRenderEffect(() => console.log("count =", count()));
+createRenderEffect(() => console.log("count =", getCount()));
 // render effect runs immediately, printing `count = 0`
 console.log("hello");
 setCount(1); // effect won't run yet

--- a/content/references/api-reference/special-jsx-attributes/classList.mdx
+++ b/content/references/api-reference/special-jsx-attributes/classList.mdx
@@ -38,9 +38,9 @@ The value passed into `classList` can be any expression (including a signal gett
 <div classList={{ [className()]: classOn() }} />;
 
 // Signal class list
-const [classes, setClasses] = createSignal({});
+const [getClasses, setClasses] = createSignal({});
 setClasses((c) => ({ ...c, active: true }));
-<div classList={classes()} />;
+<div classList={getClasses()} />;
 ```
 
 It's also possible, but dangerous, to mix class and classList. The main safe situation is when class is set to a static string (or nothing), and classList is reactive. (class could also be set to a static computed value as in `class={baseClass()}`, but then it should appear before any classList pseudo-attributes.) If both class and classList are reactive, you can get unexpected behavior: when the class value changes, Solid sets the entire class attribute, so will overwrite any toggles made by classList.

--- a/content/references/api-reference/special-jsx-attributes/use_.mdx
+++ b/content/references/api-reference/special-jsx-attributes/use_.mdx
@@ -9,7 +9,7 @@ function directive(element: Element, accessor: () => any): void;
 Directive functions are called at render time but before being added to the DOM. You can do whatever you'd like in them including create signals, effects, register clean-up etc.
 
 ```tsx
-const [name, setName] = createSignal("");
+const [getName, setName] = createSignal("");
 
 function model(el, value) {
   const [field, setField] = value();
@@ -17,7 +17,7 @@ function model(el, value) {
   el.addEventListener("input", (e) => setField(e.target.value));
 }
 
-<input type="text" use:model={[name, setName]} />;
+<input type="text" use:model={[getName, setName]} />;
 ```
 
 To register with TypeScript extend the JSX namespace.

--- a/content/references/concepts/reactivity/index.mdx
+++ b/content/references/concepts/reactivity/index.mdx
@@ -42,14 +42,14 @@ We create a signal using Solid's `createSignal` function. This returns the gette
 ```jsx
 import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(1);
+const [getCount, setCount] = createSignal(1);
 
-console.log(count()); // prints "1"
+console.log(getCount()); // prints "1"
 
 setCount(0); // Sets the count value to 0
 ```
 
-In this example, count is the getter and setCount is the setter.
+In this example, getCount is the getter and setCount is the setter.
 
 ### Effects
 
@@ -60,10 +60,10 @@ For example, the following effect will `console.log` the count whenever it updat
 ```jsx
 import { createSignal, createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 createEffect(() => {
-  console.log(count());
+  console.log(getCount());
 });
 ```
 
@@ -84,10 +84,10 @@ function createSignal() {}
 
 function createEffect() {}
 
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 createEffect(() => {
-  console.log("The count is " + count());
+  console.log("The count is " + getCount());
 });
 ```
 
@@ -172,14 +172,14 @@ function createEffect(fn) {
 This is all the code needed to create a basic reactive system. We can demonstrate that it works by incrementing the `count` value every second and watching the console.
 
 ```jsx
-const [count, setCount] = createSignal(0);
+const [getCount, setCount] = createSignal(0);
 
 createEffect(() => {
-  console.log("The count is " + count());
+  console.log("The count is " + getCount());
 });
 
 setInterval(() => {
-  setCount(count() + 1);
+  setCount(getCount() + 1);
 }, 1000);
 ```
 
@@ -200,12 +200,12 @@ So what happens if our `createEffect` function looks like this?
 ```jsx
 createEffect(() => {
   setTimeout(() => {
-    console.log(count());
+    console.log(getCount());
   }, 1000);
 });
 ```
 
-Our `createEffect` implementation doesn't wait around for this `setTimeout` callback to execute, so by the time we call our `count` getter, there is no subscriber in the global scope. The `count` signal won't register this callback as one of its subscribers.
+Our `createEffect` implementation doesn't wait around for this `setTimeout` callback to execute, so by the time we call our `getCount` getter, there is no subscriber in the global scope. The `getCount` signal won't register this callback as one of its subscribers.
 
 <Aside type="advanced" title="Handling asynchronous effects">
 

--- a/content/references/concepts/reactivity/tracking.mdx
+++ b/content/references/concepts/reactivity/tracking.mdx
@@ -18,26 +18,26 @@ This doesn't just apply to signals created with `createSignal` - props and store
 
 ```jsx
 function Counter() {
-  const [count, setCount] = createSignal(0);
-  const increment = () => setCount(count() + 1);
+  const [getCount, setCount] = createSignal(0);
+  const increment = () => setCount(getCount() + 1);
 
-  /* When count() is called, the "count" signal is tracked as a subscription of this effect,
+  /* When getCount() is called, the "count" signal is tracked as a subscription of this effect,
     so this code reruns when (and only when) count changes */
   createEffect(() => {
-    console.log("My effect says " + count());
+    console.log("My effect says " + getCount());
   })
 
-  /* This code isn't in a "tracking scope", so count()
+  /* This code isn't in a "tracking scope", so getCount()
      doesn't do anything special and this code never reruns */
-  console.log(count());
+  console.log(getCount());
 
   return (
     /*
       JSX is a tracking scope (it uses effects behind the scenes), so this code
-      registers count as a subscription when count() is called
+      registers getCount as a subscription when getCount() is called
     */
     <button type="button" onClick={increment}>
-      {count()}
+      {getCount()}
     </button>
   );
 }
@@ -49,19 +49,19 @@ Let's look at some examples where we can apply **the tracking rule of thumb** to
 
 ### Derived State
 
-In this example, the paragraph won't update when `count` changes, because `count` was accessed outside of a tracking scope.
+In this example, the paragraph won't update when `getCount` changes, because `getCount` was accessed outside of a tracking scope.
 
 ```jsx
 function Counter() {
-  const [count, setCount] = createSignal(0);
-  const increment = () => setCount(count() + 1);
+  const [getCount, setCount] = createSignal(0);
+  const increment = () => setCount(getCount() + 1);
 
-  const doubleCount = count() * 2;
+  const doubleCount = getCount() * 2;
   return (
     <>
       <p>Twice my count: {doubleCount}</p>
       <button type="button" onClick={increment}>
-        {count()}
+        {getCount()}
       </button>
     </>
   );
@@ -69,19 +69,19 @@ function Counter() {
 ```
 
 The solution is to turn `doubleCount` into a _function_. That way, when `doubleCount` is used
-in the JSX, `count()` will be called and a subscription will be registered.
+in the JSX, `getCount()` will be called and a subscription will be registered.
 
 ```jsx
 function Counter() {
-  const [count, setCount] = createSignal(0);
-  const increment = () => setCount(count() + 1);
+  const [getCount, setCount] = createSignal(0);
+  const increment = () => setCount(getCount() + 1);
 
-  const doubleCount = () => count() * 2;
+  const doubleCount = () => getCount() * 2;
   return (
     <>
       <p>Twice my count: {doubleCount()}</p>
       <button type="button" onClick={increment}>
-        {count()}
+        {getCount()}
       </button>
     </>
   );
@@ -100,14 +100,14 @@ function DoubleCountView(props) {
 }
 
 function Counter() {
-  const [count, setCount] = createSignal(0);
-  const increment = () => setCount(count() + 1);
+  const [getCount, setCount] = createSignal(0);
+  const increment = () => setCount(getCount() + 1);
 
   return (
     <>
-      <DoubleCountView value={count()} />
+      <DoubleCountView value={getCount()} />
       <button type="button" onClick={increment}>
-        {count()}
+        {getCount()}
       </button>
     </>
   );

--- a/content/references/concepts/state-management/context.mdx
+++ b/content/references/concepts/state-management/context.mdx
@@ -82,10 +82,10 @@ import { createContext, useContext, createSignal } from "solid-js";
 const MyContext = createContext(["default value",() => {}]);
 
 function App() {
-  const [value, setValue] = createSignal("new value");
+  const [getValue, setValue] = createSignal("new value");
 
   return (
-    <MyContext.Provider value={[value, setValue]}>
+    <MyContext.Provider value={[getValue, setValue]}>
       <Child />
       <button onClick={() => setValue("new value")}>Update value</button>
     </MyContext.Provider>
@@ -93,10 +93,10 @@ function App() {
 }
 
 function Child() {
-  const [value, setValue] = useContext(MyContext);
+  const [getValue, setValue] = useContext(MyContext);
   return (
     <div>
-      <div>{value()}</div>
+      <div>{getValue()}</div>
       <button onClick={() => setValue("new value")}>Update value</button>
     </div>
   );

--- a/notes/context-async.md
+++ b/notes/context-async.md
@@ -38,9 +38,9 @@ Wrap the provider so that the end user doesn't have to deal with the `.Provider`
 
 ```jsx
 export function CounterProvider(props) {
-  const [count, setCount] = createSignal(props.count || 0),
+  const [getCount, setCount] = createSignal(props.count || 0),
     store = [
-      count,
+      getCount,
       {
         increment() {
           setCount((c) => c + 1);
@@ -87,16 +87,16 @@ The problem with that approach for Solid is due to how our initial render works.
 
 ```jsx
 function Counter() {
-  const [count, setCount] = createSignal(0);
+  const [getCount, setCount] = createSignal(0);
 
-  const increment = () => setCount(count() + 1);
+  const increment = () => setCount(getCount() + 1);
 
   return (() => {
     const _el$ = _tmpl$.cloneNode(true);
 
     _el$.$$click = increment;
 
-    insert(_el$, count);
+    insert(_el$, getCount);
 
     return _el$;
   })();
@@ -129,7 +129,7 @@ return (
     <button type="button" onClick={increment}>
       Click
     </button>
-    {count() % 2 ? count() : ""}
+    {getCount() % 2 ? getCount() : ""}
   </>
 );
 ```
@@ -146,15 +146,15 @@ return [
   })(),
   memo(
     (() => {
-      const _c$ = memo(() => count() % 2, true);
+      const _c$ = memo(() => getCount() % 2, true);
 
-      return () => (_c$() ? count() : "");
+      return () => (_c$() ? getCount() : "");
     })()
   ),
 ];
 ```
 
-(Ryan starts saying that this is a bad example, but the point is that) There's a subscription to `count` inside that outer memo. The signal outlives the memo, so if you didn't have a cleanup step, you'd be adding more and more subscriptions to `count` each time the memo runs.
+(Ryan starts saying that this is a bad example, but the point is that) There's a subscription to `getCount` inside that outer memo. The signal outlives the memo, so if you didn't have a cleanup step, you'd be adding more and more subscriptions to `getCount` each time the memo runs.
 
 That's one half of why we have createRoot: it handles this cleanup for us. The other reason is because it helps us schedule effects, so they run after render. It's the reason why refs work in `onMount` or `createEffect`. We do all of the pure computation work, then do the rendering, then run the effects, synchronously. So we need to control execution, and createRoot lets us execute effects after render.
 

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 function CopyButton(props: Props) {
-  const [copied, setCopied] = createSignal(false);
+  const [getCopied, setCopied] = createSignal(false);
 
   function copyToClipboard() {
     navigator.clipboard.writeText(props.parentRef.innerText);
@@ -16,7 +16,7 @@ function CopyButton(props: Props) {
 
   return (
     <button onclick={copyToClipboard} class="absolute top-4 right-4 opacity-70">
-      <Show when={copied()} fallback={<BiSolidCopy size={24} />}>
+      <Show when={getCopied()} fallback={<BiSolidCopy size={24} />}>
         Copied!
       </Show>
     </button>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -24,9 +24,9 @@ export const CodeTabs = (props: CodeTabsProps) => {
     (el) => el.default
   );
 
-  const [selectedIndex, setSelectedIndex] = createSignal(initialSelectedIndex === -1 ? 0 : initialSelectedIndex);
+  const [getSelectedIndex, setSelectedIndex] = createSignal(initialSelectedIndex === -1 ? 0 : initialSelectedIndex);
   
-  const selectedFile = () => selectedTabSet()[selectedIndex()];
+  const selectedFile = () => selectedTabSet()[getSelectedIndex()];
 
   return (
     <div class="my-10 w-full">
@@ -37,7 +37,7 @@ export const CodeTabs = (props: CodeTabsProps) => {
               <button
                 aria-label={`Display the ${file.name} code`}
                 classList={{
-                  "border-b-2 border-blue-400": i() === selectedIndex(),
+                  "border-b-2 border-blue-400": i() === getSelectedIndex(),
                   "p-2": true,
                 }}
                 onClick={() => setSelectedIndex(i())}

--- a/src/components/configurable/Aside.tsx
+++ b/src/components/configurable/Aside.tsx
@@ -89,7 +89,7 @@ interface AsideProps {
 }
 
 export const Aside = (props: ParentProps<AsideProps>) => {
-  const [showContent, setShowContent] = createSignal(!props.collapsible);
+  const [getShowContent, setShowContent] = createSignal(!props.collapsible);
   const definition = asideDefinition()[props.type || "general"];
   const bgColor = () => props.bgColor || definition.bgColor || false;
   const preferDark = () =>
@@ -117,18 +117,18 @@ export const Aside = (props: ParentProps<AsideProps>) => {
             <button
               aria-label={`Show expanded ${title()} content`}
               class="flex gap-3"
-              onClick={() => setShowContent(!showContent())}
+              onClick={() => setShowContent(!getShowContent())}
             >
               {title()}
               <CollapsedIcon
                 class={`flex-0 transform ${
-                  showContent() ? "rotate-0" : "-rotate-90 -translate-y-px"
+                  getShowContent() ? "rotate-0" : "-rotate-90 -translate-y-px"
                 }`}
               />
             </button>
           </h3>
         </Show>
-        <Show when={showContent()}>{props.children}</Show>
+        <Show when={getShowContent()}>{props.children}</Show>
       </div>
     </div>
   );

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -12,7 +12,7 @@ import { NavPreferences } from "./NavPreferences";
 import { Collapsible, NavItem } from "./NavSection";
 
 export default function Nav(props: { docsMode: "start" | "regular" }) {
-  const [showMenu, setShowMenu] = createSignal(false);
+  const [getShowMenu, setShowMenu] = createSignal(false);
   const location = useLocation();
 
   createEffect((prev) => {
@@ -27,7 +27,7 @@ export default function Nav(props: { docsMode: "start" | "regular" }) {
       <div class="flex flex-col gap-4">
         <NavHeader
           docsMode={props.docsMode}
-          showMenu={showMenu()}
+          showMenu={getShowMenu()}
           setShowMenu={setShowMenu}
         />
       </div>
@@ -37,7 +37,7 @@ export default function Nav(props: { docsMode: "start" | "regular" }) {
       </div>
       <div
         classList={{
-          hidden: !showMenu(),
+          hidden: !getShowMenu(),
           "lg:block border-b md:border-none border-solid-lightitem dark:border-solid-darkitem pb-4":
             true,
         }}

--- a/src/components/nav/NavPreferences.tsx
+++ b/src/components/nav/NavPreferences.tsx
@@ -4,7 +4,7 @@ import IconGear from "~icons/heroicons-solid/cog";
 import { Preferences } from "../Preferences";
 
 export function NavPreferences(props: {id: string}) {
-  const [collapsed, setCollapsed] = createSignal(false);
+  const [getCollapsed, setCollapsed] = createSignal(false);
 
   return (
     <div class="border border-solid-lightitem bg-solid-light dark:bg-solid-dark dark:border-solid-darkitem rounded-lg">
@@ -22,11 +22,11 @@ export function NavPreferences(props: {id: string}) {
         </div>
         <IconChevron
           class={`w-6 h-6 text-solid-lightaction dark:text-solid-darkaction transform transition ${
-            !collapsed() ? "rotate-90" : ""
+            !getCollapsed() ? "rotate-90" : ""
           }`}
         />
       </button>
-      <Show when={!collapsed()}>
+      <Show when={!getCollapsed()}>
         <div aria-label="preferences" class="p-4 border-t border-solid-lightitem dark:border-solid-darkitem">
           <Preferences id={props.id} />
         </div>

--- a/src/components/nav/NavSection.tsx
+++ b/src/components/nav/NavSection.tsx
@@ -13,7 +13,7 @@ type CollapsibleProps = ParentProps<{
 }>;
 
 export function Collapsible(props: CollapsibleProps) {
-  const [collapsed, setCollapsed] = createSignal(props.startCollapsed() || false);
+  const [getCollapsed, setCollapsed] = createSignal(props.startCollapsed() || false);
 
   const id = createUniqueId();
 
@@ -25,13 +25,13 @@ export function Collapsible(props: CollapsibleProps) {
   return (
     <li value={props.header} class="m-2">
       <SectionHeader
-        collapsed={collapsed()}
+        collapsed={getCollapsed()}
         onClick={() => setCollapsed((prev) => !prev)}
         panelId={id}
       >
         {props.header}
       </SectionHeader>
-      <Show when={!collapsed()}>
+      <Show when={!getCollapsed()}>
         <SectionPanel id={id}>{props.children}</SectionPanel>
       </Show>
     </li>

--- a/src/components/nav/Summary.tsx
+++ b/src/components/nav/Summary.tsx
@@ -6,7 +6,7 @@ import { useRouteData } from "solid-start";
 
 export default function Summary(props: {collapsed?: boolean}) {
     const { sections } = usePageState();
-    const [collapsed, setCollapsed] = createSignal(props.collapsed || false);
+    const [getCollapsed, setCollapsed] = createSignal(props.collapsed || false);
 
     return (
         <div class="py-2 px-4 border border-solidlightitem rounded-md md:(p-4 max-h-[95vh] overflow-auto border-none bg-transparent) max-h-[50vh] bg-solid-light z-50 dark:(bg-solid-dark md:bg-transparent border-solid-darkitem)">
@@ -19,7 +19,7 @@ export default function Summary(props: {collapsed?: boolean}) {
                 Summary
                 <IconChevron
                     class={`md:hidden w-6 h-6 text-solid-lightaction dark:text-solid-darkaction transform transition ${
-                    !collapsed() ? "rotate-90" : ""
+                    !getCollapsed() ? "rotate-90" : ""
                     }`}
                 />
             </button>
@@ -33,7 +33,7 @@ export default function Summary(props: {collapsed?: boolean}) {
                 </li>
                 )}
             </For>
-            <Show when={!collapsed()}>
+            <Show when={!getCollapsed()}>
                 <ol class="mt-2 md:hidden list-none space-y-1">
                 <For each={sections()}>
                     {(item, index) => (


### PR DESCRIPTION
It seems that something a lot of people get tripped up on is that signals work _almost_ the same as React hooks, but not quite because the first item in the returned array is a getter function instead of a value. Why not name the function properly to avoid confusion? #278 suggests this rename in new documentation.

One thing that wasn't clear to me while making this change is how to reword all of the comments. The comments use the old name of the getter (often times `count`). Since the `count` variable has been renamed to `getCount` it's appropriate to update the name in the comments, but it isn't obvious that _all_ occurrences of `count` should be renamed. If the getter and setter are named `getCount` and `setCount`, then it doesn't seem unexpected to refer to the state variable being saved as `count` even though there is no variable called `count` anymore.

For example, is this section updated properly or does it need more attention? (This is one of the easier comments I encountered)

[content/guides/foundations/solid-primitives.mdx:65](https://github.com/solidjs/solid-docs-next/blob/07f948c0376681e655dc7490e45b6300ae6f3788/content/guides/foundations/solid-primitives.mdx#L65)
> In the example above we have a `getCount` function that is used to keep track of the current count. We have two functions, `increment` and `decrement` that are used to update the `count` state variable. We also have a component, `Counter` that uses the `getCount` function to display the current count.