### PR TITLE
Update solid-primitives.mdx

### DIFF
--- a/content/guides/foundations/solid-primitives.mdx
+++ b/content/guides/foundations/solid-primitives.mdx
@@ -100,16 +100,6 @@ As you've noticed in the example above, we are using `createSignal` outside of a
 
 `createMemo` is used to create a reactive state variable that is derived from other reactive state variables. It takes a function that returns the value of the state variable and returns a getter function to get the current value.
 
-```js
-import { createSignal, createMemo } from "solid-js";
-
-const [count, setCount] = createSignal(0);
-
-const double = createMemo(() => count() * 2);
-```
-
-~~In the example above we have a `count` state variable that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.~~ Text repeated below code example.
-
 Here's a quick example of how you can make use of `createMemo` to create a memoized derived state and make use of it in a component.
 
 ```js

--- a/content/guides/foundations/solid-primitives.mdx
+++ b/content/guides/foundations/solid-primitives.mdx
@@ -108,7 +108,7 @@ const [count, setCount] = createSignal(0);
 const double = createMemo(() => count() * 2);
 ```
 
-In the example above we have a `count` state variable that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.
+~~In the example above we have a `count` state variable that is used to keep track of the current count. We also have a `double` state variable that is derived from the `count` state variable. The `double` state variable is a memoized version of the `count` state variable. This means that the `double` state variable will only be recomputed when the `count` state variable changes.~~ Text repeated below code example.
 
 Here's a quick example of how you can make use of `createMemo` to create a memoized derived state and make use of it in a component.
 


### PR DESCRIPTION
I added a strikethrough to a paragraph because it is repeated. The paragraph first appears above the code block and is then repeated below the code block.