### PR TITLE
add EraserLink component, use it for links to Eraser

### DIFF
--- a/src/components/EraserLink.tsx
+++ b/src/components/EraserLink.tsx
@@ -62,8 +62,13 @@ const EraserLink = ({
 		<div class="relative">
 			<Link href={linkUrl}>
 				<img src={imageUrl} alt={""} />
+				<img
+					src="https://firebasestorage.googleapis.com/v0/b/second-petal-295822.appspot.com/o/images%2Fgithub%2FOpen%20in%20Eraser.svg?alt=media&token=968381c8-a7e7-472a-8ed6-4a6626da5501
+			"
+					class="absolute top-4 right-4"
+					alt="Open in Eraser"
+				/>
 			</Link>
-			<div class="absolute top-1 right-2">Eraser</div>
 		</div>
 	)
 }

--- a/src/components/EraserLink.tsx
+++ b/src/components/EraserLink.tsx
@@ -44,7 +44,14 @@ const EraserLink = ({
 		: `${workspaceUrl}?${ERASER_TRACKING_PARAMS}`
 
 	if (children !== undefined) {
-		return <Link href={linkUrl}>{children}</Link>
+		return (
+			<Link
+				href={linkUrl}
+				class="dark:text-solid-darklink break-normal text-solid-lightlink duration-100 ease-in transition font-semibold leading-normal transition hover:underline"
+			>
+				{children}
+			</Link>
+		)
 	}
 
 	const imageUrl = elementParams

--- a/src/components/EraserLink.tsx
+++ b/src/components/EraserLink.tsx
@@ -1,0 +1,64 @@
+import { Link } from "@solidjs/router"
+import { ParentProps } from "solid-js"
+
+const ERASER_TRACKING_PARAMS = ""
+
+type EraserLinkData = {
+	workspaceId: string
+	elementsId?: string
+}
+
+export const getEraserLinkData = (href: string): EraserLinkData | void => {
+	const matches = /app.eraser.io\/workspace\/(\w+)(.*elements=(\w+))?/.exec(
+		href
+	)
+
+	if (!matches) {
+		return
+	}
+
+	if (matches[3]) {
+		return {
+			workspaceId: matches[1],
+			elementsId: matches[3],
+		}
+	}
+	return {
+		workspaceId: matches[1],
+	}
+}
+
+const EraserLink = ({
+	linkData,
+	children,
+}: ParentProps<{
+	linkData: EraserLinkData
+}>) => {
+	const workspaceUrl = `https://app.eraser.io/workspace/${linkData.workspaceId}`
+	const elementParams = linkData.elementsId
+		? `elements=${linkData.elementsId}`
+		: ""
+
+	const linkUrl = elementParams
+		? `${workspaceUrl}?${elementParams}&${ERASER_TRACKING_PARAMS}`
+		: `${workspaceUrl}?${ERASER_TRACKING_PARAMS}`
+
+	if (children !== undefined) {
+		return <Link href={linkUrl}>{children}</Link>
+	}
+
+	const imageUrl = elementParams
+		? `${workspaceUrl}/preview?${elementParams}&type=embed`
+		: `${workspaceUrl}/preview`
+
+	return (
+		<div class="relative">
+			<Link href={linkUrl}>
+				<img src={imageUrl} alt={""} />
+			</Link>
+			<div class="absolute top-1 right-2">Eraser</div>
+		</div>
+	)
+}
+
+export default EraserLink

--- a/src/md.tsx
+++ b/src/md.tsx
@@ -7,6 +7,7 @@ import { Title } from "./components/Main"
 import { Title as MetaTitle } from "@solidjs/meta"
 import { usePageState } from "~/components/context/PageStateContext"
 import CopyButton from "./components/CopyButton"
+import EraserLink, { getEraserLinkData } from "./components/EraserLink"
 
 function Anchor(props: ParentProps<{ id: string }>) {
 	return (
@@ -16,6 +17,21 @@ function Anchor(props: ParentProps<{ id: string }>) {
 		>
 			{props.children}
 		</a>
+	)
+}
+
+function EraserLinkOrNormalLink(props: ParentProps<{ href: string }>) {
+	const eraserLinkData = getEraserLinkData(props.href)
+	if (eraserLinkData) {
+		return <EraserLink linkData={eraserLinkData}>{props.children}</EraserLink>
+	}
+	return (
+		<Link
+			{...props}
+			class="dark:text-solid-darklink break-normal text-solid-lightlink duration-100 ease-in transition font-semibold leading-normal transition hover:underline"
+		>
+			{props.children}
+		</Link>
 	)
 }
 
@@ -100,16 +116,7 @@ export default {
 			{props.children}
 		</p>
 	),
-	a: (props) => {
-		return (
-			<Link
-				{...props}
-				class="dark:text-solid-darklink break-normal text-solid-lightlink duration-100 ease-in transition font-semibold leading-normal transition hover:underline"
-			>
-				{props.children}
-			</Link>
-		)
-	},
+	a: EraserLinkOrNormalLink,
 	li: (props) => (
 		<li {...props} class="mb-2">
 			{props.children}


### PR DESCRIPTION
@LadyBluenotes here's an Eraser link!

This adds an EraserLink component and conditionally uses it to render markdown links.

It will do one of three things:

1. If a link is not an Eraser workspace link, render a link like normal
2. If a link is an Eraser workspace link, and has children, render it like a normal link with tracking parameters
3. If a link is an Eraser workspace link, and has _no_ children, render an image of the link.

Examples:

```
[This is a link to Solid.js's website](https://www.solidjs.com/)

[This is an Eraser link with text](https://app.eraser.io/workspace/w9y9PNVjwSqDCEPNTEoe?elements=5bE5kc7N_kOSfyHtasalrg)

[](https://app.eraser.io/workspace/w9y9PNVjwSqDCEPNTEoe?elements=5bE5kc7N_kOSfyHtasalrg)
```

renders this:

<img width="759" alt="image" src="https://github.com/solidjs/solid-docs-next/assets/339327/487cb2d8-4e61-4048-937e-aded5da66a35">

