### PR TITLE
Create indexhtmljsx.mdx

### DIFF
--- a/content/guides/tutorials/getting-started-with-solid/snippets/indexhtmljsx.mdx
+++ b/content/guides/tutorials/getting-started-with-solid/snippets/indexhtmljsx.mdx
@@ -1,0 +1,18 @@
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="shortcut icon" type="image/ico" href="/src/assets/favicon.ico" />
+    <title>Solid App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+
+    <script src="/src/index.tsx" type="module"></script>
+  </body>
+</html>
+```


### PR DESCRIPTION
index.html snippet under the js examples has a typo where .tsx is used instead of .jsx creating new indexhtmljsx.mdx file to have distinction between js and ts snippets.

will reflect same change in the building-ui-with-components.mdx as well. and rename the index mdx used for ts snippets