### PR TITLE
Fix incorrect parameter reference

### DIFF
--- a/content/references/api-reference/basic-reactivity/createResource.mdx
+++ b/content/references/api-reference/basic-reactivity/createResource.mdx
@@ -58,7 +58,7 @@ const [data, { mutate, refetch }] = createResource(fetchData);
 const [data, { mutate, refetch }] = createResource(source, fetchData);
 ```
 
-In these snippets, the fetcher is the function `fetchData`, and `data()` is undefined until `fetchData` finishes resolving. In the first case, `fetchData` will be called immediately. In the second, `fetchData` will be called as soon as `sourceSignal` has any value other than false, null, or undefined. It will be called again whenever the value of `sourceSignal` changes, and that value will always be passed to `fetchData` as its first argument.
+In these snippets, the fetcher is the function `fetchData`, and `data()` is undefined until `fetchData` finishes resolving. In the first case, `fetchData` will be called immediately. In the second, `fetchData` will be called as soon as `source` has any value other than false, null, or undefined. It will be called again whenever the value of `source` changes, and that value will always be passed to `fetchData` as its first argument.
 
 You can call `mutate` to directly update the `data` signal (it works like any other signal setter). You can also call refetch to rerun the fetcher directly, and pass an optional argument to provide additional info to the fetcher e.g `refetch(info)`.
 


### PR DESCRIPTION
The explanatory text refers to a `sourceSignal` parameter but the function signature calls the parameter `source`. I've changed the reference in the text to match the signature but perhaps the signature should be changed?