### PR TITLE
Fix name of author in BookshelfExample components

### DIFF
--- a/content/guides/tutorials/getting-started-with-solid/components/BasicBookshelf.tsx
+++ b/content/guides/tutorials/getting-started-with-solid/components/BasicBookshelf.tsx
@@ -10,7 +10,7 @@ type Book = {
 const initialBooks: Book[] = [
   { title: "Code Complete", author: "Steve McConnell" },
   { title: "The Hobbit", author: "J.R.R. Tolkien" },
-  { title: "Living a Feminist Life", author: "Sarah Ahmed" },
+  { title: "Living a Feminist Life", author: "Sara Ahmed" },
 ];
 
 interface IBookshelfProps {

--- a/content/guides/tutorials/getting-started-with-solid/components/FinishedBookshelf.tsx
+++ b/content/guides/tutorials/getting-started-with-solid/components/FinishedBookshelf.tsx
@@ -12,7 +12,7 @@ type Book = {
 const initialBooks: Book[] = [
   { title: "Code Complete", author: "Steve McConnell" },
   { title: "The Hobbit", author: "J.R.R. Tolkien" },
-  { title: "Living a Feminist Life", author: "Sarah Ahmed" },
+  { title: "Living a Feminist Life", author: "Sara Ahmed" },
 ];
 
 interface IBookshelfProps {


### PR DESCRIPTION
The author of the third example book "Living a Feminist Life" is incorrectly spelled Sara**h** instead of Sara. This has been changed in this PR.

See https://www.saranahmed.com or https://en.wikipedia.org/wiki/Sara_Ahmed for confirmation