### PR TITLE
Fix Typo/Syntax Error on "Understanding Components" Guide

### DIFF
--- a/content/guides/foundations/understanding-components.mdx
+++ b/content/guides/foundations/understanding-components.mdx
@@ -213,7 +213,7 @@ function MyComponent(props) {
   // This is a good practice and will update within the component when the prop value changes
   const [name, setName] = createSignal(props.name) // createSignal is a Solid primitive. More on this in the next page 
 
-  return <div>Hello {name}</div>
+  return <div>Hello {name()}</div>
 }
 ```
 


### PR DESCRIPTION
Hey all! This is my first encounter with Solid. I was reading through the docs to get a better understanding and noticed this typo/syntax error. 

Also wanted to mention that I found the end of this guide, [What are Component Props?](https://docs.solidjs.com/guides/foundations/understanding-components#what-are-component-props) a little confusing. I think for me the confusion arose from calling the `name` prop a reactive value here

```js
function App() {
  return (
    <div>
      <MyComponent name="John Doe" />
    </div>
  )
}
```

I would've expected the prop to look something like this for it to be considered a reactive value

```js
function App() {
  const [name, setName] = createSignal("John Doe");

  return (
    <div>
      <MyComponent name={name()} />
    </div>
  )
}
```