### PR TITLE
Fix typos in fetching-data.mdx

### DIFF
--- a/content/guides/fetching-data.mdx
+++ b/content/guides/fetching-data.mdx
@@ -20,9 +20,9 @@ These properties can be used to conditionally render JSX based on the current re
 The fetcher function that is created makes a call to get a user, which is then passed in as an argument to `createResource`. 
 
 The signal returned from the `createResource` provides the properties that help can assist with conditional rendering based on the current reactive state:
-* `state`: The current status of the opertaion (`unresolved`, `pendign`, `ready`, `refreshing`, or `errored`).
+* `state`: The current status of the operation (`unresolved`, `pending`, `ready`, `refreshing`, or `errored`).
 * `loading`: Indicates that the operation is currently in progress via a `boolean`.
-* `error`: If the operation fails for any reason, this peroperty will contain information about this error.
+* `error`: If the operation fails for any reason, this property will contain information about this error.
 It may be a string with an error message, or an object with more detailed information.
 * `latest`: The most recent data or result returned from the operation.
 


### PR DESCRIPTION
Fixed typos according to the [createResource API reference](https://docs.solidjs.com/references/api-reference/basic-reactivity/createResource)

Closes #405 

#390 is partially addressed