### PR TITLE
Solid Router has no "Routes" Export

### DIFF
--- a/content/guides/how-to-guides/routing-in-solid/solid-router.mdx
+++ b/content/guides/how-to-guides/routing-in-solid/solid-router.mdx
@@ -59,14 +59,12 @@ Now that we have the router setup we can define some routes. Let's start by maki
 ```jsx
 import { render } from "solid-js/web";
 import App from "./App";
-import { Router, Route, Routes } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
         <Route path="/" component={App} /> {/* 👈 Define the home page route */}
-      </Routes>
     </Router>
   ),
   document.getElementById("app")


### PR DESCRIPTION
The current version of Sold Router no longer supports <Routes> https://github.com/solidjs/solid-router?tab=readme-ov-file#outlet-routes-useroutes