### PR TITLE
Fix a typo in understanding-components.mdx

### DIFF
--- a/content/guides/foundations/understanding-components.mdx
+++ b/content/guides/foundations/understanding-components.mdx
@@ -126,7 +126,7 @@ function MyComponent() {
 }
 ```
 
-In the above example, the component will not return the `Count limit reached` div if the count is greater than 5. This is because the component itself is not reactive and is only used once so it does not know when the state of `count` gets above 5. In order to make the `Count limit reached` visible, we need to use add it to a reactive scope like the returned JSX and make use of the logic in there. Here's an example of how this can be done:
+In the above example, the component will not return the `Count limit reached` div if the count is greater than 5. This is because the component itself is not reactive and is only used once so it does not know when the state of `count` gets above 5. In order to make the `Count limit reached` visible, we need to add it to a reactive scope like the returned JSX and make use of the logic in there. Here's an example of how this can be done:
 
 ```jsx
 function MyComponent() {


### PR DESCRIPTION
Just finished reading the ‘[Why are Components Different in Solid?](https://docs.solidjs.com/references/concepts#why-are-components-different-in-solid)’ section and found a typo.