### PR TITLE
fix typo in documentation

### DIFF
--- a/content/references/api-reference/control-flow/Suspense.mdx
+++ b/content/references/api-reference/control-flow/Suspense.mdx
@@ -43,7 +43,7 @@ const MyComponent = () => {
 }
 ```
 
-## Understanding the purpose of {"<Suspense>"} in Solid:
+## Understanding the purpose of `<Suspense>` in Solid:
 
 To understand the purpose of suspense, let's consider the following code snippets. These snippets will have some drawbacks which we will solve by using suspense. We will also see how it is possible to use suspense yet not reap its benefits.
 


### PR DESCRIPTION
`{"<Suspense>"}` is not rendered in the title

https://docs.solidjs.com/references/api-reference/control-flow/Suspense#understanding-the-purpose-of--in-solid

<img width="799" alt="image" src="https://github.com/solidjs/solid-docs-next/assets/737729/5e40261a-f209-445c-bea7-c05152e26b57">

The fixed version looks like this:

<img width="797" alt="image" src="https://github.com/solidjs/solid-docs-next/assets/737729/aef60dca-6e70-4a78-933c-7d8732a7d167">

