### PR TITLE
fix: remove unneeded <Routes />

### DIFF
--- a/content/guides/how-to-guides/routing-in-solid/solid-router.mdx
+++ b/content/guides/how-to-guides/routing-in-solid/solid-router.mdx
@@ -59,39 +59,35 @@ Now that we have the router setup we can define some routes. Let's start by maki
 ```jsx
 import { render } from "solid-js/web";
 import App from "./App";
-import { Router, Route, Routes } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} /> {/* 👈 Define the home page route */}
-      </Routes>
+      <Route path="/" component={App} /> {/* 👈 Define the home page route */}
     </Router>
   ),
   document.getElementById("app")
 );
 ```
 
-In the code above we have imported the `Route` and `Routes` component from Solid Router and defined a route for the home page. The `Route` component takes a `path` prop which is the URL path that the route will match. The `component` prop is the component that will be rendered when the route is matched. The `Routes` component is used to group routes together and is required for nested routes. This component is used to show where the routes should be rendered.
+In the code above we have imported the `Route` component from Solid Router and defined a route for the home page. The `Route` component takes a `path` prop which is the URL path that the route will match. The `component` prop is the component that will be rendered when the route is matched.
 
-You can add multiple routes under the `Routes` component and they will be rendered whenever the URL matches the route's path. Let's add a route for the `/about` and `/contact` pages.
+You can add multiple routes under the `Router` component and they will be rendered whenever the URL matches the route's path. Let's add a route for the `/about` and `/contact` pages.
 
 ```jsx
 import { render } from "solid-js/web";
 import App from "./App";
 import About from "./About";
 import Contact from "./Contact";
-import { Router, Route, Routes } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} /> {/* 👈 Define the about page route */}
-        <Route path="/contact" component={Contact} /> {/* 👈 Define the contact page route */}
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} /> {/* 👈 Define the about page route */}
+      <Route path="/contact" component={Contact} /> {/* 👈 Define the contact page route */}
     </Router>
   ),
   document.getElementById("app")
@@ -103,7 +99,7 @@ __Note:__ If you would like to lazy load your components so that they are only l
 ```jsx
 import { render } from "solid-js/web";
 import App from "./App";
-import { Router, Route, Routes } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 import { lazy } from "solid-js";
 
 const About = lazy(() => import("./About"));
@@ -112,11 +108,9 @@ const Contact = lazy(() => import("./Contact"));
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} /> {/* 👈 Define the about page route */}
-        <Route path="/contact" component={Contact} /> {/* 👈 Define the contact page route */}
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} /> {/* 👈 Define the about page route */}
+      <Route path="/contact" component={Contact} /> {/* 👈 Define the contact page route */}
     </Router>
   ),
   document.getElementById("app")
@@ -167,16 +161,14 @@ import { render } from "solid-js/web";
 import App from "./App";
 import About from "./About";
 import Contact from "./Contact";
-import { Router, Route, Routes, A } from "@solidjs/router";
+import { Router, Route, A } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} />
-        <Route path="/contact" component={Contact} />
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} />
+      <Route path="/contact" component={Contact} />
     </Router>
   ),
   document.getElementById("app")
@@ -259,17 +251,15 @@ import App from "./App";
 import About from "./About";
 import User from "./User";
 import Contact from "./Contact";
-import { Router, Route, Routes, A } from "@solidjs/router";
+import { Router, Route, A } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} />
-        <Route path="/user/:id" component={User} /> {/* 👈 Add a dynamic route */}
-        <Route path="/contact" component={Contact} />
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} />
+      <Route path="/user/:id" component={User} /> {/* 👈 Add a dynamic route */}
+      <Route path="/contact" component={Contact} />
     </Router>
   ),
   document.getElementById("app")
@@ -357,17 +347,15 @@ import App from "./App";
 import About from "./About";
 import User from "./User";
 import Contact from "./Contact";
-import { Router, Route, Routes, A } from "@solidjs/router";
+import { Router, Route, A } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} />
-        <Route path="/user/:id?" component={User} /> {/* 👈 Make the id parameter optional */}
-        <Route path="/contact" component={Contact} />
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} />
+      <Route path="/user/:id?" component={User} /> {/* 👈 Make the id parameter optional */}
+      <Route path="/contact" component={Contact} />
     </Router>
   ),
   document.getElementById("app")
@@ -388,17 +376,15 @@ import App from "./App";
 import About from "./About";
 import User from "./User";
 import Contact from "./Contact";
-import { Router, Route, Routes, A } from "@solidjs/router";
+import { Router, Route, A } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} />
-        <Route path="/user/*" component={User} /> {/* 👈 Make the id parameter a wildcard */}
-        <Route path="/contact" component={Contact} />
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} />
+      <Route path="/user/*" component={User} /> {/* 👈 Make the id parameter a wildcard */}
+      <Route path="/contact" component={Contact} />
     </Router>
   ),
   document.getElementById("app")
@@ -415,17 +401,15 @@ import App from "./App";
 import About from "./About";
 import User from "./User";
 import Contact from "./Contact";
-import { Router, Route, Routes, A } from "@solidjs/router";
+import { Router, Route, A } from "@solidjs/router";
 
 render(
   () => (
     <Router>
-      <Routes>
-        <Route path="/" component={App} />
-        <Route path="/about" component={About} />
-        <Route path="/user/*id" component={User} /> {/* 👈 Name the wildcard parameter */}
-        <Route path="/contact" component={Contact} />
-      </Routes>
+      <Route path="/" component={App} />
+      <Route path="/about" component={About} />
+      <Route path="/user/*id" component={User} /> {/* 👈 Name the wildcard parameter */}
+      <Route path="/contact" component={Contact} />
     </Router>
   ),
   document.getElementById("app")


### PR DESCRIPTION
Removes the usage of <Routes /> from documentation which is not required/exported anymore. Relates to #384.

There's still the 'Nested Routes' section at the end which I'm not sure is replaced with what. If anyone knows please let me know, else I'll update once I learn nested routes :smile:  