### PR TITLE
Open links in a new tab

### DIFF
--- a/src/ui/layout/main-header.tsx
+++ b/src/ui/layout/main-header.tsx
@@ -42,7 +42,13 @@ export function MainHeader() {
 				</A>
 				<div class="flex basis-0 gap-4">
 					<ThemeSelector />
-					<A href="https://github.com" class="group" aria-label="GitHub">
+					<A
+						href="https://github.com/solidjs/solid-docs-next"
+						class="group"
+						aria-label="GitHub"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
 						<GitHubIcon class="h-6 w-6 dark:fill-slate-400 group-hover:dark:fill-slate-500 dark:group-hover:fill-slate-300" />
 					</A>
 				</div>

--- a/src/ui/markdown-components.tsx
+++ b/src/ui/markdown-components.tsx
@@ -114,7 +114,9 @@ export default {
 		const [, rest] = splitProps(props, ["children"]);
 		const resolved = children(() => props.children);
 		const resolvedArray = resolved.toArray();
-
+		let extraAttrs = {};
+		if (props.href.startsWith("https://") || props.href.startsWith("http://"))
+			extraAttrs = { target: "_blank", rel: "noopener noreferrer" };
 		if (
 			// Server side
 			(isServer &&
@@ -131,8 +133,7 @@ export default {
 			return (
 				<A
 					class="[&>code]:shadow-[0_0_0_1px_#38bdf8] hover:[&>code]:shadow-[0_0_0_2px_#38bdf8]"
-					target="_blank"
-					rel="noopener noreferrer"
+					{...extraAttrs}
 					{...rest}
 				>
 					{resolved()}
@@ -143,8 +144,7 @@ export default {
 				<A
 					{...rest}
 					class={`no-underline shadow-[inset_0_-2px_0_0_var(--tw-prose-background,#38bdf8),inset_0_calc(-1*(var(--tw-prose-underline-size,2px)+2px))_0_0_var(--tw-prose-underline,theme(colors.sky.400))] hover:[--tw-prose-underline-size:4px] dark:[--tw-prose-background:theme(colors.slate.900)] dark:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.sky.800))] dark:hover:[--tw-prose-underline-size:6px] dark:text-sky-400 text-sky-700 font-semibold`}
-					target="_blank"
-					rel="noopener noreferrer"
+					{...extraAttrs}
 				>
 					{resolved()}
 				</A>

--- a/src/ui/markdown-components.tsx
+++ b/src/ui/markdown-components.tsx
@@ -131,6 +131,8 @@ export default {
 			return (
 				<A
 					class="[&>code]:shadow-[0_0_0_1px_#38bdf8] hover:[&>code]:shadow-[0_0_0_2px_#38bdf8]"
+					target="_blank"
+					rel="noopener noreferrer"
 					{...rest}
 				>
 					{resolved()}
@@ -141,6 +143,8 @@ export default {
 				<A
 					{...rest}
 					class={`no-underline shadow-[inset_0_-2px_0_0_var(--tw-prose-background,#38bdf8),inset_0_calc(-1*(var(--tw-prose-underline-size,2px)+2px))_0_0_var(--tw-prose-underline,theme(colors.sky.400))] hover:[--tw-prose-underline-size:4px] dark:[--tw-prose-background:theme(colors.slate.900)] dark:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.sky.800))] dark:hover:[--tw-prose-underline-size:6px] dark:text-sky-400 text-sky-700 font-semibold`}
+					target="_blank"
+					rel="noopener noreferrer"
 				>
 					{resolved()}
 				</A>


### PR DESCRIPTION
- Made all markdown links open in new tabs
- Same behaviour applies for the GitHub link
- Made GitHub link point to the docs repository, rather than the base GitHub site