### PR TITLE
Configure rehypeAutoLinkHeadings + add className to a tag for headings

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,10 @@
 		scroll-padding-top: 6rem;
 		color-scheme: light;
 	}
+  
+  .heading{
+    color: #F1F5F9 !important;
+  }
 
 	html.dark {
 		color-scheme: dark;

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,10 +11,6 @@
 		scroll-padding-top: 6rem;
 		color-scheme: light;
 	}
-  
-  .heading{
-    color: #F1F5F9 !important;
-  }
 
 	html.dark {
 		color-scheme: dark;
@@ -73,6 +69,16 @@
 	.shiki.material-theme-ocean {
 		background-color: transparent !important;
 	}
+}
+
+@layer utilities {
+  .heading{
+    @apply shadow-none text-slate-900 dark:text-white !important;
+  }
+
+  .heading:hover::after{
+    @apply opacity-80; content: ' #';
+  }
 }
 
 .navigation_collapsible {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -82,7 +82,12 @@ export default defineConfig({
 					},
 				],
 				[rehypeSlug],
-				[rehypeAutoLinkHeadings],
+				[rehypeAutoLinkHeadings, {
+          behavior: 'wrap',
+          properties : {
+              className : "heading",
+          },
+        }],
 			],
 			remarkPlugins: [
 				remarkFrontmatter,


### PR DESCRIPTION
Seems like rehypeAutoLinkHeadings needed the `behavior: 'wrap'` option in order to work.

I additionally added a `className` called `heading` (which is optional) to try to overide the default anchor style values that seem to be set globally in [this part](https://github.com/solidjs/solid-docs-next/blob/81ed9b969667577c8b903cb8cdef3fdc95bc1798/src/ui/markdown-components.tsx#L32), my intention was to keep the previous styling for the titles but feel free to remove or change that, it still has the underline and hover effect.

![image](https://github.com/solidjs/solid-docs-next/assets/66949816/93ca87e4-f701-4e06-9a1e-cadd20ea17aa)

closes https://github.com/solidjs/solid-docs-next/issues/427