### PR TITLE
fixed table of content layout

### DIFF
--- a/src/ui/layout/side-panel.tsx
+++ b/src/ui/layout/side-panel.tsx
@@ -4,8 +4,7 @@ import { TableOfContents } from "./table-of-contents";
 
 export const SidePanel: Component = () => {
 	return (
-		<div class="hidden xl:block relative">
-			<div class="fixed">
+		<div class="hidden shrink-0 fixed right-4 xl:block">
 				<TableOfContents />
 				<Contribute />
 			</div>

--- a/src/ui/layout/table-of-contents.tsx
+++ b/src/ui/layout/table-of-contents.tsx
@@ -31,7 +31,7 @@ export const TableOfContents: Component = () => {
 	});
 
 	return (
-		<aside aria-label="table of contents" class="w-full">
+		<aside aria-label="table of contents" class="w-full max-w-64">
 			<span class="font-display text-base font-medium text-slate-900 dark:text-white">
 				On this page
 			</span>


### PR DESCRIPTION
<img width="320" alt="Screenshot 2024-02-14 at 9 12 46 PM" src="https://github.com/solidjs/solid-docs-next/assets/69889565/70a55f27-4f4b-4de4-a9fa-bc8c390d8545">

After changes,

<img width="320" alt="Screenshot 2024-02-14 at 9 26 38 PM" src="https://github.com/solidjs/solid-docs-next/assets/69889565/5d8a751e-e039-43bd-8fe0-6078c3910e67">
