### PR TITLE
chore: update light mode colors

### DIFF
--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -14,7 +14,7 @@ export const Layout: ParentComponent<{ isError?: boolean }> = (props) => {
 	return (
 		<PageStateProvider>
 			<div class="relative">
-				<Alert.Root class="dark:text-slate-900 text-white text-center bg-[#0e8ee7] dark:bg-[#a2deff] p-1 font-semibold border-blue-00  dark:border-blue-600">
+				<Alert.Root class="dark:text-slate-900 text-white text-center bg-[#2c4f7c] dark:bg-[#a2deff] p-1 font-semibold border-blue-00  dark:border-blue-600">
 					These docs are currently in Beta!{" "}
 					<a class="underline" href="https://shr.link/pna6n">
 						Share your feedback with us!

--- a/src/ui/layout/main-navigation.tsx
+++ b/src/ui/layout/main-navigation.tsx
@@ -20,7 +20,7 @@ function ListItemLink(props: { item: Entry }) {
 	const linkStyles = () =>
 		location.pathname === props.item.path.replace(/\\/g, "/")
 			? "font-semibold text-blue-800 before:bg-blue-700 dark:before:bg-blue-200 dark:text-blue-300 before:block"
-			: "text-slate-500 before:hidden before:bg-blue-600 before:dark:bg-blue-200 hover:text-blue-500 hover:font-bold hover:before:block dark:text-slate-300 ";
+			: "text-slate-600 before:hidden before:bg-blue-600 before:dark:bg-blue-200 hover:text-blue-500 hover:font-bold hover:before:block dark:text-slate-300 ";
 	return (
 		<li class="relative">
 			<A
@@ -41,7 +41,7 @@ function DirList(props: { list: Entry[] }) {
 				if (Array.isArray(item.children)) {
 					return (
 						<li>
-							<span class="font-display font-semibold text-slate-700 dark:text-slate-100 lg:text-sm">
+							<span class="font-display font-semibold text-slate-800 dark:text-slate-100 lg:text-sm">
 								{item.title}
 							</span>
 							<ul

--- a/src/ui/pagination.tsx
+++ b/src/ui/pagination.tsx
@@ -38,7 +38,7 @@ export function Pagination(props: Pagination) {
 							Previous
 						</span>
 						<A
-							class="flex items-center gap-x-1 text-base font-medium text-slate-500 hover:text-blue-600 dark:text-slate-300 dark:hover:text-blue-300 flex-row-reverse no-underline"
+							class="flex items-center gap-x-1 text-base font-medium text-slate-600 hover:text-blue-600 dark:text-slate-300 dark:hover:text-blue-300 flex-row-reverse no-underline"
 							href={entry().path}
 						>
 							← {entry().title}
@@ -53,7 +53,7 @@ export function Pagination(props: Pagination) {
 							Next
 						</span>
 						<A
-							class="flex items-center gap-x-1 text-base font-medium text-slate-500 hover:text-blue-700 dark:text-slate-300 dark:hover:text-blue-300 flex-row-reverse no-underline"
+							class="flex items-center gap-x-1 text-base font-medium text-slate-600 hover:text-blue-700 dark:text-slate-300 dark:hover:text-blue-300 flex-row-reverse no-underline"
 							href={entry().path}
 						>
 							{entry().title} →

--- a/src/ui/tab-code-blocks.tsx
+++ b/src/ui/tab-code-blocks.tsx
@@ -67,7 +67,7 @@ export const TabsCodeBlocks = (props: Props) => {
 					{(tab, idx) => (
 						<button
 							classList={{
-								"font-bold dark:text-slate-300 text-blue-500 border-b-2 border-blue-400":
+								"font-bold dark:text-slate-300 text-blue-600 border-b-2 border-blue-400":
 									activeTab() === idx,
 								"px-5 py-1 relative top-0.5 transition-colors duration-300":
 									true,


### PR DESCRIPTION
- light mode colors are darkened to address a11y concerns
- background color for Alert Box is referred from [solidjs media](https://www.solidjs.com/media)
- Manual testing using [axe DevTools Chrome extension](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
- Partially Addresses #469
- Suggested Label: a11y

> The subjective concerns in the mentioned Issue are not addressed _YET_ but I would like to have them discussed before pushing down any changes