### PR TITLE
Fix invalid variable name

### DIFF
--- a/src/routes/concepts/context.mdx
+++ b/src/routes/concepts/context.mdx
@@ -95,7 +95,7 @@ const Provider = (props) => (
 )
 
 const Child = () => {
-	const value = useContext(Context)
+	const value = useContext(MyContext)
 	return <>{value}</>
 }
 


### PR DESCRIPTION
Pretty sure it was supposed to be `MyContext` instead of `Context`.