### PR TITLE
Fix formatting in list-rendering example

### DIFF
--- a/src/routes/concepts/control-flow/list-rendering.mdx
+++ b/src/routes/concepts/control-flow/list-rendering.mdx
@@ -39,9 +39,11 @@ Index is a [*signal*](/concepts/signals) and must be called as a function to ret
 ```jsx
 <For each={data()}>
 	{(item, index) => (
-		<li style={{
-            color: index() % 2 === 0 ? "red" : "blue"
-          }}>
+		<li
+			style={{
+				color: index() % 2 === 0 ? "red" : "blue"
+			}}
+		>
 			{item.name}
 		</li>
 	)}


### PR DESCRIPTION
I don't know if the solid docs follow any specific conventions, so I decided to format using `prettier`.