### PR TITLE
fix: callout overflow & link clipping

### DIFF
--- a/src/ui/callout.tsx
+++ b/src/ui/callout.tsx
@@ -79,7 +79,7 @@ export function Callout(props: CalloutProps) {
 			}`}
 		>
 			<IconComponent class={`h-6 w-8 pt-1 flex-none`} />
-			<div class={`m-0 pb-1 px-4 w-full ${styles[mergedProps.type].title}`}>
+			<div class={`m-0 pb-1 px-4 ${styles[mergedProps.type].title}`} style="width: calc(100% - 2rem);">
 				<Show
 					when={props.title}
 					fallback={

--- a/src/ui/markdown-components.tsx
+++ b/src/ui/markdown-components.tsx
@@ -136,7 +136,7 @@ export default {
 		) {
 			return (
 				<A
-					class="[&>code]:shadow-[0_0_0_1.5px_#2563eb] hover:[&>code]:shadow-[0_0_0_2px_#1e3a8a] dark:[&>code]:shadow-[0_0_0_1.5px_#bae6fd] dark:hover:[&>code]:shadow-[0_0_0_2px_#FFFFFF]"
+					class="[&>code]:shadow-[0_0_0_1.5px_#2563eb] hover:[&>code]:shadow-[0_0_0_2px_#1e3a8a] dark:[&>code]:shadow-[0_0_0_1.5px_#bae6fd] dark:hover:[&>code]:shadow-[0_0_0_2px_#FFFFFF] [&>code]:mx-[2px]"
 					{...extraAttrs}
 					{...rest}
 				>


### PR DESCRIPTION
fixes overflow on https://docs.solidjs.com/concepts/stores (due to callout)
closes #505 