### PR TITLE
Fixing issues with themes, code blocks, scrollbars, and other random stuff

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,47 +16,47 @@ export default function App() {
 			{(() => {
 				const ctx = useThemeContext();
 
+				createEffect(() => {
+					const html = document.documentElement;
+					html.classList.remove("light", "dark");
+					html.classList.add(ctx.selectedTheme().value);
+					html.dataset.theme = ctx.selectedTheme().theme;
+				});
+
 				return (
-					<div
-						class={ctx.selectedTheme().value}
-						data-theme={ctx.selectedTheme().value}
+					<Router
+						root={(props) => (
+							<MetaProvider>
+								<Title>Solid Docs</Title>
+								<ErrorBoundary
+									fallback={(e) => {
+										return (
+											<>
+												<Title>404 - SolidDocs</Title>
+												<Layout isError={Boolean(e)}>
+													<HttpStatusCode code={404} />
+													<div class="flex flex-col items-center">
+														<h1 class="inline pb-1 bg-gradient-to-r from-indigo-200 via-blue-400 to-indigo-200 bg-clip-text font-display text-5xl tracking-tight text-transparent">
+															Page Not Found
+														</h1>
+														<A href="/">Take me back.</A>
+													</div>
+												</Layout>
+											</>
+										);
+									}}
+								>
+									<Layout>
+										<MDXProvider components={Md}>
+											<Suspense>{props.children}</Suspense>
+										</MDXProvider>
+									</Layout>
+								</ErrorBoundary>
+							</MetaProvider>
+						)}
 					>
-						<div>
-							<Router
-								root={(props) => (
-									<MetaProvider>
-										<Title>Solid Docs</Title>
-										<ErrorBoundary
-											fallback={(e) => {
-												return (
-													<>
-														<Title>404 - SolidDocs</Title>
-														<Layout isError={Boolean(e)}>
-															<HttpStatusCode code={404} />
-															<div class="flex flex-col items-center">
-																<h1 class="inline pb-1 bg-gradient-to-r from-indigo-200 via-blue-400 to-indigo-200 bg-clip-text font-display text-5xl tracking-tight text-transparent">
-																	Page Not Found
-																</h1>
-																<A href="/">Take me back.</A>
-															</div>
-														</Layout>
-													</>
-												);
-											}}
-										>
-											<Layout>
-												<MDXProvider components={Md}>
-													<Suspense>{props.children}</Suspense>
-												</MDXProvider>
-											</Layout>
-										</ErrorBoundary>
-									</MetaProvider>
-								)}
-							>
-								<FileRoutes />
-							</Router>
-						</div>
-					</div>
+						<FileRoutes />
+					</Router>
 				);
 			})()}
 		</ThemeProvider>

--- a/src/data/theme-provider.tsx
+++ b/src/data/theme-provider.tsx
@@ -28,9 +28,9 @@ type ThemeContext = {
 };
 
 function getCookie(name: string, cookieString: string) {
-	let value = `; ${cookieString}`;
-	let parts = value.split(`; ${name}=`);
-	if (parts.length === 2) return parts.pop()!.split(";").shift() || "system";
+	if (!name || !cookieString) return "system";
+	const match = cookieString.match(new RegExp(`\\W?${name}=(?<theme>\\w+)`));
+	return match?.groups?.theme || "system";
 }
 
 const ThemeCtx = createContext<ThemeContext>();
@@ -69,7 +69,7 @@ export const ThemeProvider = (props: ParentProps) => {
 		setSelectedTheme(themes[2]);
 	});
 	createEffect(() => {
-		document.cookie = `theme=${selectedTheme().value}`;
+		document.cookie = `theme=${selectedTheme().value};path=/`;
 	});
 	return (
 		<ThemeCtx.Provider

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -4,7 +4,7 @@ export default createHandler(() => (
 	<StartServer
 		document={({ assets, children, scripts }) => {
 			return (
-				<html lang="en" class="custom-scrollbar">
+				<html lang="en" data-theme="min-light">
 					<head>
 						<meta charset="utf-8" />
 						<meta

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,24 +1,33 @@
 import { createHandler, StartServer } from "@solidjs/start/server";
+import { ThemeProvider, useThemeContext } from "./data/theme-provider";
 
 export default createHandler(() => (
 	<StartServer
 		document={({ assets, children, scripts }) => {
 			return (
-				<html lang="en" data-theme="min-light">
-					<head>
-						<meta charset="utf-8" />
-						<meta
-							name="viewport"
-							content="width=device-width, initial-scale=1"
-						/>
-						<link rel="icon" href="/favicon.ico" />
-						{assets}
-					</head>
-					<body>
-						<div id="app">{children}</div>
-						{scripts}
-					</body>
-				</html>
+				<ThemeProvider>
+					{(() => {
+						const ctx = useThemeContext();
+
+						return (
+							<html lang="en" class={ctx.selectedTheme().value} data-theme={ctx.selectedTheme().theme}>
+								<head>
+									<meta charset="utf-8" />
+									<meta
+										name="viewport"
+										content="width=device-width, initial-scale=1"
+									/>
+									<link rel="icon" href="/favicon.ico" />
+									{assets}
+								</head>
+								<body>
+									<div id="app">{children}</div>
+									{scripts}
+								</body>
+							</html>
+						)
+					})()}
+				</ThemeProvider>
 			);
 		}}
 	/>

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,10 +11,34 @@ html {
 }
 
 @layer base {
-	.custom-scrollbar {
-		scrollbar-color: #334155 #cbd5e1;
-		scrollbar-width: thin;
+	/* Scroll bar */
+	.custom-scrollbar::-webkit-scrollbar-track {
+		@apply bg-transparent;
 	}
+
+	.custom-scrollbar::-webkit-scrollbar {
+		@apply w-5 h-5 bg-slate-200/80 rounded-xl border-[6px] border-solid border-transparent;
+		background-clip: content-box;
+	}
+	.dark .custom-scrollbar::-webkit-scrollbar {
+		@apply bg-slate-600/60;
+	}
+
+	.custom-scrollbar::-webkit-scrollbar-thumb {
+		@apply bg-slate-600/70 rounded-xl border-[6px] border-solid border-transparent;
+		background-clip: content-box;
+	}
+	.dark .custom-scrollbar::-webkit-scrollbar-thumb {
+		@apply bg-slate-400/90;
+	}
+
+	.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+		@apply bg-slate-600;
+	}
+	.dark .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+		@apply bg-slate-200/70;
+	}
+	
 
 	.prose h1,
 	.prose h2 {

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -14,26 +14,6 @@ html .expressive-code-overrides .expressive-code pre {
 	@apply rounded-xl border-[1.5px];
 }
 
-html:not(.dark) .expressive-code-overrides .expressive-code pre {
-	border-color: hsl(214 71% 86% / 1);
-	background-color: hsl(216deg 100% 98.4%);
-
-}
-
-html.dark .expressive-code-overrides .expressive-code pre {
-	@apply border-slate-800/75;
-	background-color: hsl(222 70% 8% / 1);
-}
-
-.expressive-code-overrides .expressive-code pre > code {
-	@apply font-mono bg-transparent tracking-wide;
-	filter: brightness(1.06) contrast(1.35);
-}
-
-html.dark .expressive-code-overrides .expressive-code pre > code {
-	filter: brightness(1.06) contrast(1.35) saturate(1.3)
-}
-
 /* Copy Button */
 .expressive-code-overrides .expressive-code .copy button::before {
 	@apply dark:border-slate-500 border-blue-900 opacity-30
@@ -47,15 +27,21 @@ html.dark .expressive-code-overrides .expressive-code pre > code {
 	@apply dark:bg-slate-300/80 bg-blue-950/70;
 }
 html .expressive-code-overrides .expressive-code .copy button div {
-	@apply bg-blue-300/60
+	@apply bg-blue-300/60;
 }
 .expressive-code-overrides .expressive-code .copy .feedback {
 	@apply bg-blue-500 transition-all dark:bg-blue-300 dark:text-blue-950 tracking-wide;
-	font-family: var(--font-lexend)
+	font-family: var(--font-lexend);
 }
 
 .expressive-code-overrides .expressive-code .copy .feedback::after {
 	@apply border-l-blue-500 transition-all dark:border-l-blue-300;
+}
+
+/* Title */
+.expressive-code-overrides .expressive-code .frame {
+	--tab-border-radius: 0.75rem;
+	--header-border-radius: 0.75rem;
 }
 
 
@@ -72,7 +58,29 @@ html.dark .expressive-code-overrides .expressive-code .ec-line.mark  {
 
 
 /* Scroll bar */
-.expressive-code-overrides .expressive-code pre {
-	scrollbar-color: #8a99ae rgb(71 85 105 / 0.3);
-	scrollbar-width: thin;
+.expressive-code-overrides .expressive-code pre::-webkit-scrollbar-track {
+	@apply bg-transparent;
+}
+
+.expressive-code-overrides .expressive-code pre::-webkit-scrollbar {
+	@apply w-5 h-5 bg-slate-200/80 rounded-xl border-[6px] border-solid border-transparent;
+	background-clip: content-box;
+}
+.dark .expressive-code-overrides .expressive-code pre::-webkit-scrollbar {
+	@apply bg-slate-600/60;
+}
+
+.expressive-code-overrides .expressive-code pre::-webkit-scrollbar-thumb {
+	@apply bg-slate-600/70 rounded-xl border-[6px] border-solid border-transparent;
+	background-clip: content-box;
+}
+.dark .expressive-code-overrides .expressive-code pre::-webkit-scrollbar-thumb {
+	@apply bg-slate-400/90;
+}
+
+.expressive-code-overrides .expressive-code pre::-webkit-scrollbar-thumb:hover {
+	@apply bg-slate-600;
+}
+.dark .expressive-code-overrides .expressive-code pre::-webkit-scrollbar-thumb:hover {
+	@apply bg-slate-200/70;
 }

--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -79,7 +79,7 @@ export const DocsLayout: ParentComponent = (props) => {
 					<span class="xl:hidden text-sm">
 						<EditPageLink />
 					</span>
-					<div class="max-w-prose w-full overflow-y-auto">{props.children}</div>
+					<div class="max-w-prose w-full">{props.children}</div>
 					<span class="xl:hidden text-sm">
 						<PageIssueLink />
 					</span>

--- a/src/ui/layout/main-navigation.tsx
+++ b/src/ui/layout/main-navigation.tsx
@@ -101,20 +101,20 @@ export function MainNavigation() {
 	return (
 		<nav class="overflow-y-auto custom-scrollbar h-full md:h-[calc(100vh-7rem)] pb-20">
 			<Tabs.Root defaultValue={isReference() ? "reference" : "learn"}>
-				<Tabs.List class="sticky top-0 w-full pb-4 z-10 dark:bg-slate-900 bg-slate-50">
+				<Tabs.List class="sticky top-0 flex w-full pb-4 pr-4 z-10 md:dark:bg-slate-900 md:bg-slate-50">
 					<Tabs.Trigger
 						value="learn"
-						class="inline-block ml-2 px-6 py-2 outline-none hover:bg-blue-500/30 dark:hover:bg-blue-300  dark:focus-visible:bg-blue-800 dark:text-slate-100 hover:dark:text-slate-800 hover:font-bold"
+						class="inline-block flex-1 ml-2 px-6 py-2 outline-none hover:bg-blue-500/30 dark:hover:bg-blue-300/20  dark:focus-visible:bg-blue-800 dark:text-slate-100 hover:font-bold"
 					>
 						Learn
 					</Tabs.Trigger>
 					<Tabs.Trigger
 						value="reference"
-						class="inline-block px-6 py-2 hover:bg-blue-500/30 dark:hover:bg-blue-300  dark:focus-visible:bg-blue-800 dark:text-slate-100 hover:dark:text-slate-800 hover:font-bold"
+						class="inline-block flex-1 px-6 py-2 hover:bg-blue-500/30 dark:hover:bg-blue-300/20  dark:focus-visible:bg-blue-800 dark:text-slate-100 hover:font-bold"
 					>
 						Reference
 					</Tabs.Trigger>
-					<Tabs.Indicator class="absolute bg-blue-500 dark:bg-blue-500 transition-all duration-250 h-[2px]" />
+					<Tabs.Indicator class="absolute bottom-4 bg-blue-500 dark:bg-blue-500 transition-all duration-250 h-[2px]" />
 				</Tabs.List>
 				<Tabs.Content value="learn" class="w-full relative mt-8 text-base">
 					<Show when={learn()} fallback={<p>No routes found...</p>}>

--- a/src/ui/layout/mobile-navigation.tsx
+++ b/src/ui/layout/mobile-navigation.tsx
@@ -16,7 +16,7 @@ export const MobileNavigation = () => {
 				<div class="fixed inset-0 z-50 flex justify-start">
 					<Dialog.Overlay class="bg-white/10 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in fixed inset-0 z-50 backdrop-blur-sm transition-all duration-100" />
 					<Dialog.Content class="w-5/6 sm:w-2/3 h-full border-none dark:bg-slate-900 bg-slate-50 z-50 scale-100 border px-3 opacity-100 shadow-lg overflow-y-auto flex flex-col">
-						<Dialog.CloseButton class="sticky top-0 self-end pt-4 mb-3 z-10">
+						<Dialog.CloseButton class="sticky top-0 self-end pt-4 mb-3 z-20">
 							<Icon path={xMark} class="w-6 dark:prose-invert prose" />
 						</Dialog.CloseButton>
 						<Dialog.Description class="pr-3 w-full">

--- a/src/ui/markdown-components.tsx
+++ b/src/ui/markdown-components.tsx
@@ -121,6 +121,8 @@ export default {
 		let extraAttrs = {};
 		if (props.href.startsWith("https://") || props.href.startsWith("http://"))
 			extraAttrs = { target: "_blank", rel: "noopener noreferrer" };
+
+		// Check if the link is a code block
 		if (
 			// Server side
 			(isServer &&
@@ -136,7 +138,7 @@ export default {
 		) {
 			return (
 				<A
-					class="[&>code]:shadow-[0_0_0_1.5px_#2563eb] hover:[&>code]:shadow-[0_0_0_2px_#1e3a8a] dark:[&>code]:shadow-[0_0_0_1.5px_#bae6fd] dark:hover:[&>code]:shadow-[0_0_0_2px_#FFFFFF]"
+					class="[&>code]:shadow-[0_0_0_1.5px_#2563eb] hover:[&>code]:shadow-[0_0_0_2px_#1e3a8a] dark:[&>code]:shadow-[0_0_0_1.5px_#38bdf8] dark:hover:[&>code]:shadow-[0_0_0_2px_#7dd3fc]"
 					{...extraAttrs}
 					{...rest}
 				>
@@ -146,9 +148,9 @@ export default {
 		} else {
 			return (
 				<A
-					{...rest}
 					class={`no-underline shadow-[inset_0_-2px_0_0_var(--tw-prose-background,#38bdf8),inset_0_calc(-1*(var(--tw-prose-underline-size,2px)+2px))_0_0_var(--tw-prose-underline,theme(colors.blue.400))] hover:[--tw-prose-underline-size:4px] dark:[--tw-prose-background:theme(colors.slate.900)] dark:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.blue.500))] dark:hover:[--tw-prose-underline-size:6px] dark:text-blue-300 text-blue-800 font-semibold`}
 					{...extraAttrs}
+					{...rest}
 				>
 					{resolved()}
 				</A>
@@ -189,7 +191,7 @@ export default {
 		return (
 			<pre
 				{...props}
-				class=" [&>code]:p-0 [&>code]:text-sm [&>code]:leading-normal custom-scroll-bar"
+				class="[&>code]:bg-white dark:[&>code]:!bg-slate-950 [&>code]:p-0 [&>code]:text-sm [&>code]:leading-normal custom-scroll-bar"
 			>
 				{props.children}
 			</pre>
@@ -198,7 +200,7 @@ export default {
 	code: (props: ParentProps) => {
 		return (
 			<code
-				class="inline-block not-prose font-mono font-medium bg-blue-200 dark:bg-blue-700/60 text-slate-900 dark:text-white px-1 py-0.5 rounded-lg text-[0.8em] leading-snug"
+				class="inline-block not-prose !font-mono font-medium bg-blue-200 dark:bg-slate-600/60 text-slate-900 dark:text-white px-1 py-0.5 rounded-lg text-[0.8em] leading-snug"
 				{...props}
 			>
 				{props.children}


### PR DESCRIPTION
- theme selector itself was always light theme even when set to dark (out of scope of the .dark class)
- expressive code theme selector wasn't doing anything (needed to be on the html element to work)
- recent expressive code custom styles were applying filter and background colors that were messing with the look of the code blocks a lot, so I removed them. My guess was this was an attempt to fix the previous problem.
- new scrollbar styles still applied to the main page/window scrollbars which is something we were trying to avoid and they also don't look as good (set it back to custom scrollbars but only for in-page elements like the nav and code blocks, leaving the main scrollbar as browser default)
-  .overflow-y-auto in the docs-layout.tsx file was causing the code blocks box shadow to get clipped on the side and appeared unnecessary so I removed it 
- fixed mobile nav tab background covering the close button 
- idk why the inline code blocks on dark theme were changed to a blue color that doesn't match the theme but it does not look good, switched it back to a slate color
- fixed server rending of theme class and attribute so there is no initial flash of the wrong theme
- improved theme cookie setting and getting