### PR TITLE
add `color-scheme` to match theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5,12 +5,18 @@
 @import "tailwindcss/utilities";
 @import "./styles/fonts.css";
 
-html {
-	scroll-behavior: smooth;
-	scroll-padding-top: 6rem;
-}
 
 @layer base {
+	html {
+		scroll-behavior: smooth;
+		scroll-padding-top: 6rem;
+		color-scheme: light;
+	}
+
+	html.dark {
+		color-scheme: dark;
+	}
+
 	/* Scroll bar */
 	.custom-scrollbar::-webkit-scrollbar-track {
 		@apply bg-transparent;


### PR DESCRIPTION
- [x] moves `html {}` definitions inside tailwind's base layer
- [x] adds `color-scheme` to match native components to theme 