### PR TITLE
refactor: update edit issue link for new templates

### DIFF
--- a/src/ui/page-issue-link.tsx
+++ b/src/ui/page-issue-link.tsx
@@ -13,7 +13,7 @@ export const PageIssueLink: Component = () => {
 	return (
 		<a
 			class="flex no-underline hover:font-bold hover:text-blue-700 dark:hover:text-blue-300 dark:text-slate-300 "
-			href={`https://github.com/solidjs/solid-docs-next/issues/new?title=${path()}.mdx Issue`}
+			href={`https://github.com/solidjs/solid-docs-next/issues/new?assignees=ladybluenotes&labels=improve+documentation%2Cpending+review&projects=&template=CONTENT.yml&title=[Content]:&subject=${path()}.mdx`}
 		>
 			<Icon class="mr-1" path={exclamationTriangle} style="width: 16px;" />
 			Report an issue with this page


### PR DESCRIPTION
# What does it do?

- we have just added new issue templates. This PR updates our "there is an issue with this page" link to make use of the Content template