### PR TITLE
Correct capitalization if anchor tag - Update linking-routes.mdx

### DIFF
--- a/src/routes/routing/linking-routes.mdx
+++ b/src/routes/routing/linking-routes.mdx
@@ -50,8 +50,8 @@ const Home = lazy(() => import("./pages/Home"));
 const App = (props) => (
 	<>
 		<nav>
-			<A href="/about">About</a>
-			<A href="/">Home</a>
+			<A href="/about">About</A>
+			<A href="/">Home</A>
 		</nav>
 		<h1>My Site with lots of pages</h1>
 		{props.children}


### PR DESCRIPTION
The end anchor tag in two locations should be capitalized.