### PR TITLE
Fix named export example in basics.mdx

### DIFF
--- a/src/routes/concepts/components/basics.mdx
+++ b/src/routes/concepts/components/basics.mdx
@@ -187,11 +187,20 @@ There are two ways to export a component: [named exports](https://developer.mozi
 **Named export:**
 
 Named exports allow for multiple components to be exported from a single file.
-To export a component, you must use the `export` keyword before the function definition and specify the name of the component to export in curly braces (`{}`).
+To export a component, you must use the `export` keyword before the function definition or specify the name of the component to export in curly braces (`{}`).
 
 ```typescript
 // MyComponent.ts
 export function MyComponent() {
+	return <div>Hello World</div>
+}
+```
+
+or
+
+```typescript
+// MyComponent.ts
+function MyComponent() {
 	return <div>Hello World</div>
 }
 

--- a/src/routes/concepts/components/basics.mdx
+++ b/src/routes/concepts/components/basics.mdx
@@ -190,16 +190,12 @@ Named exports allow for multiple components to be exported from a single file.
 To export a component, you must use the `export` keyword before the function definition or specify the name of the component to export in curly braces (`{}`).
 
 ```typescript
-// MyComponent.ts
 export function MyComponent() {
 	return <div>Hello World</div>
 }
-```
 
-or
+// or
 
-```typescript
-// MyComponent.ts
 function MyComponent() {
 	return <div>Hello World</div>
 }


### PR DESCRIPTION
For named export, you don't need to use export on both the function and on an object, it's one or the other.