### PR TITLE
Remove mention of dependency array in memos.mdx

### DIFF
--- a/src/routes/concepts/derived-values/memos.mdx
+++ b/src/routes/concepts/derived-values/memos.mdx
@@ -41,7 +41,7 @@ While you can use a [derived signal](/concepts/derived-values/derived-signals) t
 - When working with expensive computations, memos can be used to cache the results so they are not recomputed unnecessarily.
 - A memo will only recompute when its dependencies change, and will not trigger subsequent updates (as determiend by [`===` or strict equality](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality)) if its dependencies change but its value remains the same.
 - Any signal or memo accessed within a memo's function is **tracked**.
-  This means that the memo will re-evaluate automatically when these dependencies change, removing the need for a dependency array.
+  This means that the memo will re-evaluate automatically when these dependencies change.
 
 <EraserLink
 	href="https://app.eraser.io/workspace/maDvFw5OryuPJOwSLyK9?elements=ACJTLvgPnReEQszYSUwoLw"


### PR DESCRIPTION
The mention of "removing the need for a dependency array" is not needed and may not be understandable for those that don't have knowledge of React useMemo dependency array.