### PR TITLE
Simplify the loggedIn toggle example in dynamic value assigment section

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -208,7 +208,7 @@ These functions receive the old value as an argument, allowing you to compute th
 This dynamic approach is particularly useful for complex transformations.
 
 ```jsx
-setStore("users", 3, (loggedIn) => !users[3].loggedIn)
+setStore("users", 3, (loggedIn) => !loggedIn)
 ```
 
 ### Filtering values


### PR DESCRIPTION
I think this was probably a mistake here, it didn't use the loggedIn param.