### PR TITLE
Update linking-routes.mdx - consistent use of 'users' & 'home'

### DIFF
--- a/src/routes/routing/linking-routes.mdx
+++ b/src/routes/routing/linking-routes.mdx
@@ -15,7 +15,7 @@ const Home = lazy(() => import("./pages/Home"));
 const App = (props) => (
 	<>
 		<nav>
-			<a href="/about">About</a>
+			<a href="/users">Users</a>
 			<a href="/">Home</a>
 		</nav>
 		<h1>My Site with lots of pages</h1>
@@ -37,7 +37,7 @@ render(
 ## `<A>` Component
 
 Solid Router also offers an [`<A>`](/reference/solid-router/components/a) component.
-Similar to the HTML anchor tag, the `<A>` component is similar but it supports automatically applying the base URL path and the relative paths.
+The `<A>` component is similar to the HTML anchor tag but supports automatically applying the base URL path and relative paths.
 
 ```jsx
 import { lazy } from "solid-js";
@@ -46,11 +46,11 @@ import { Router, Route, A } from "@solidjs/router";
 
 const Users = lazy(() => import("./pages/Users"));
 const Home = lazy(() => import("./pages/Home"));
-
+H
 const App = (props) => (
 	<>
 		<nav>
-			<A href="/about">About</A>
+			<A href="/users">Users</A>
 			<A href="/">Home</A>
 		</nav>
 		<h1>My Site with lots of pages</h1>
@@ -78,7 +78,7 @@ This provides the link with a CSS class to show when the link is active or inact
 	active="underlined"
 	inactive="default"
 	>
-	About
+	Users
 </A>
 ```
 


### PR DESCRIPTION
There are two components imported into the example: Users & Home. However, routes were referenced 'about'. 

Fix: Change all instances of `About`  and `/about` to `Users` and `/users`.

Additionally, I added a suggested sentence structure change.