### PR TITLE
Add `max-age` attribute to theme cookie

### DIFF
--- a/src/data/theme-provider.tsx
+++ b/src/data/theme-provider.tsx
@@ -69,7 +69,7 @@ export const ThemeProvider = (props: ParentProps) => {
 		setSelectedTheme(themes[2]);
 	});
 	createEffect(() => {
-		document.cookie = `theme=${selectedTheme().value};path=/`;
+		document.cookie = `theme=${selectedTheme().value};path=/;max-age=${60 * 60 * 24 * 365}`;
 	});
 	return (
 		<ThemeCtx.Provider


### PR DESCRIPTION
Currently, the theme cookie expires after the session ends. This PR makes it expire after a year.