### PR TITLE
change redirect code to be 301

### DIFF
--- a/src/middleware/legacy-routes-redirect.ts
+++ b/src/middleware/legacy-routes-redirect.ts
@@ -114,6 +114,6 @@ export const handleLegacyRoutes = (event: FetchEvent) => {
 	const { pathname } = new URL(event.request.url);
 
 	if (isLegacyRoute(pathname)) {
-		return redirect(LEGACY_ROUTES[pathname], 308);
+		return redirect(LEGACY_ROUTES[pathname], 301);
 	}
 };


### PR DESCRIPTION
I see google accepts the `308` status code, but the most standard code is `301` for permanent redirects.  https://developers.google.com/search/docs/crawling-indexing/301-redirects

308 seems to be about keeping the request method (POST/ETC) and request body (files/body/etc). For example, redirecting the page when the user posts a form. I do not think we do that or need it here. 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301