### PR TITLE
Fix typos

### DIFF
--- a/src/routes/concepts/components/event-handlers.mdx
+++ b/src/routes/concepts/components/event-handlers.mdx
@@ -108,7 +108,7 @@ This means that delegated event listeners remain active even if the element that
 <div onMouseMove={handleCustomEvent} />
 ```
 
-<Callout type="tip" title="Ocassional Events">
+<Callout type="tip" title="Occasional Events">
 
 Rather than using delegated events for events that happen infrequently, **native events** are a better solution.
 Since these events happen in specific circumstances, they do not benefit from the performance improvements you get with event delegation.

--- a/src/routes/guides/complex-state-management.mdx
+++ b/src/routes/guides/complex-state-management.mdx
@@ -187,7 +187,7 @@ const toggleTask = (id) => {
 }
 ```
 
-Can be simlified using `produce`:
+Can be simplified using `produce`:
 
 ```jsx
 import { produce } from "solid-js/store"


### PR DESCRIPTION
I found two typos while reading the new documentation.