### PR TITLE
Update Solid-Router guide to latest release

### DIFF
--- a/src/routes/guides/routing-and-navigation.mdx
+++ b/src/routes/guides/routing-and-navigation.mdx
@@ -22,8 +22,11 @@ npm install @solidjs/router
 ```
 </div>
 
-<div id="yarn">```bash frame="none" yarn add @solidjs/router ```</div>
-
+<div id="yarn">
+```bash frame="none"
+ yarn add @solidjs/router
+```
+</div>
 <div id="pnpm">
 ```bash frame="none"
 pnpm i @solidjs/router

--- a/src/routes/guides/routing-and-navigation.mdx
+++ b/src/routes/guides/routing-and-navigation.mdx
@@ -369,7 +369,7 @@ You can nest indefinitely - just remember that only leaf nodes will become their
 
 ## Load Functions
 
-Even with smart caches it is possible that we have waterfalls both with view logic and with lazy loaded code. With load functions, we can instead start fetching the data parallel to loading the route, so we can use the data as soon as possible. The load function is called when the Route is loaded or eagerly when links are hovered.
+Even with smart caches, it is possible that we have waterfalls both with view logic and with lazy loaded code. With load functions, we can instead start fetching the data parallel to loading the route, so we can use the data as soon as possible. The load function is called when the Route is loaded or eagerly when links are hovered.
 
 As its only argument, the load function is passed an object that you can use to access route information:
 
@@ -395,7 +395,7 @@ function loadUser({params, location}) {
 | intent | `"initial", "navigate", "native", "preload"` | Indicates why this function is being called. <ul><li>"initial" - the route is being initially shown (ie page load)</li><li>"native" - navigate originated from the browser (eg back/forward)</li><li>"navigate" - navigate originated from the router (eg call to navigate or anchor clicked)</li><li>"preload" - not navigating, just preloading (eg link hover)</li></ul> |
 
 
-A common pattern is to export the load function and data wrappers that corresponds to a route in a dedicated `route.data.js` file. This way, the data function can be imported without loading anything else.
+A common pattern is to export the load function and data wrappers that correspond to a route in a dedicated `route.data.js` file. This way, the data function can be imported without loading anything else.
 
 ```js
 import { lazy } from "solid-js";
@@ -407,7 +407,7 @@ const User = lazy(() => import("/pages/users/[id].js"));
 <Route path="/users/:id" component={User} load={loadUser} />;
 ```
 
-The return value of the `load` function is passed to the page component when called at anytime other than `"preload"`, so you can initialize things in there, or alternatively use our new Data APIs:
+The return value of the `load` function is passed to the page component when called at any time other than `"preload"`, so you can initialize things in there, or alternatively use our new Data APIs:
 
 ## Data APIs
 
@@ -429,7 +429,7 @@ This cache accomplishes the following:
 1. It does just deduping on the server for the lifetime of the request.
 2. It does preload cache in the browser which lasts 10 seconds. When a route is preloaded on hover or when load is called when entering a route, it will make sure to dedupe calls.
 3. We have a reactive refetch mechanism based on key. So we can tell routes that aren't new to retrigger on action revalidation.
-4. It will serve as a back/forward cache for browser navigation up to 5 mins. Any user based navigation or link click bypasses it. Revalidation or new fetch updates the cache.
+4. It will serve as a back/forward cache for browser navigation up to 5 mins. Any user-based navigation or link click bypasses it. Revalidation or new fetch updates the cache.
 
 Using it with the load function might look like:
 
@@ -461,7 +461,7 @@ export default function User(props) {
 }
 ```
 
-Cached function has a few useful methods for getting the key that are useful for invalidation.
+The cached function has a few useful methods for getting the key that are useful for invalidation.
 
 ```ts
 let id = 5;
@@ -505,7 +505,7 @@ const myAction = action(async (data) => {
 
 Actions only work with post requests, so make sure to put `method="post"` on your form.
 
-Sometimes it might be easier to deal with typed data instead of `FormData` and adding additional hidden fields. For that reason, Actions have a `with` method that works similar to `bind`, which applies the arguments in order.
+Sometimes it might be easier to deal with typed data instead of `FormData` and adding additional hidden fields. For that reason, Actions have a `with` method that works similarly to `bind`, which applies the arguments in order.
 
 Picture an action that deletes Todo Item:
 
@@ -568,7 +568,7 @@ const submission = useSubmission(action, (input) => filter(input));
 
 ### Response Helpers
 
-These are used to communicate router navigations from cache/actions, and can include invalidation hints. Generally, these are thrown to not interfere the with the types and make it clear that function ends execution at that point.
+These are used to communicate router navigations from cache/actions and can include invalidation hints. Generally, these are thrown to not interfere with the types and make it clear that function ends execution at that point.
 
 #### `redirect(path, options)`
 
@@ -673,7 +673,7 @@ import { HashRouter } from "@solidjs/router";
 
 ### Memory Mode Router
 
-You can also use memory mode router for testing purposes.
+You can also use a memory mode router for testing purposes.
 
 ```jsx
 import { MemoryRouter } from "@solidjs/router";
@@ -722,7 +722,7 @@ The `<A>` tag has an `active` class if its href matches the current location, an
 | state         | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating                                                               |
 | inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link)                                                                                           |
 | activeClass   | string  | The class to show when the link is active                                                                                                                                                |
-| end           | boolean | If `true`, only considers the link to be active when the curent location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                      |
+| end           | boolean | If `true`, only considers the link to be active when the current location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                      |
 
 ### `<Navigate />`
 
@@ -878,7 +878,7 @@ The biggest changes are around removed APIs that need to be replaced.
 
 ### `<Outlet>`, `<Routes>`, `useRoutes`
 
-This is no longer used and instead will use `props.children` passed from into the page components for outlets. This keeps the outlet directly passed from its page and avoids oddness of trying to use context across Islands boundaries. Nested `<Routes>` components inherently cause waterfalls and are `<Outlets>` themselves so they have the same concerns.
+This is no longer used and instead will use `props.children` passed from into the page components for outlets. This keeps the outlet directly passed from its page and avoids the oddness of trying to use context across Islands boundaries. Nested `<Routes>` components inherently cause waterfalls and are `<Outlets>` themselves so they have the same concerns.
 
 Keep in mind no `<Routes>` means the `<Router>` API is different. The `<Router>` acts as the `<Routes>` component and its children can only be `<Route>` components. Your top-level layout should go in the root prop of the router [as shown above](#configure-your-routes)
 
@@ -888,7 +888,7 @@ Related without Outlet component it has to be passed in manually. At which point
 
 ### `data` functions & `useRouteData`
 
-These have been replaced by a load mechanism. This  allows link hover preloads (as the load function can be run as much as wanted without worry about reactivity). It supports deduping/cache APIs which give more control over how things are cached. It also addresses TS issues with getting the right types in the Component without `typeof` checks.
+These have been replaced by a load mechanism. This allows link hover preloads (as the load function can be run as much as wanted without worry about reactivity). It supports deduping/cache APIs which give more control over how things are cached. It also addresses TS issues with getting the right types in the Component without `typeof` checks.
 
 That being said you can reproduce the old pattern largely by turning off preloads at the router level and then injecting your own Context:
 
@@ -911,6 +911,7 @@ function loadUser({params, location}) {
 ```
 
 And then in your component taking the page props and putting them in a Context.
+
 ```js
 function User(props) {
   <UserContext.Provider value={props.data}>

--- a/src/routes/guides/routing-and-navigation.mdx
+++ b/src/routes/guides/routing-and-navigation.mdx
@@ -7,12 +7,13 @@ import { TabsCodeBlocks } from "~/ui/tab-code-blocks";
 
 Solid Router simplifies routing in Solid applications to help developers manage navigation and rendering by defining routes using JSX or objects passed via props.
 
-## Getting Started
+## Routing Quick Start
 
-### Set Up the Router
+Solid Router allows you to configure your routes using JSX. This section will demonstrate how to set up routes and navigate to them using the `Router`, `Route` and `A` components. Additionally, we will add a root component which acts as a page layout.
 
-1. Install `@solidjs/router`.
-   This package is not included by default.
+**1. Install the Router**
+
+This package is not included by default.
 
 <TabsCodeBlocks>
 <div id="npm">
@@ -30,651 +31,926 @@ pnpm i @solidjs/router
 </div>
 </TabsCodeBlocks>
 
-2. To use the router, import the `Router` component to wrap the root component.
-   This allows the routes to be displayed throughout the entire application.
+**2. Setup the `Router` component**
+
+Start your application by rendering the router component.
 
 ```jsx
 import { render } from "solid-js/web";
-import App from "./App";
 import { Router } from "@solidjs/router";
 
 render(
-	() => (
-		<Router>
-			<App />
-		</Router>
-	),
-	document.getElementById("root")
+  () => <Router />,
+  document.getElementById("app")
 );
 ```
 
-### Configure the Routes
+This sets up a Router that will match on the url to display the desired page.
 
-Solid Router offers a convenient way to configure routes using `JSX` syntax:
+**3. Provide a Root Level Layout**
 
-1. Using the `Routes` component, you can specify where the routes should appear in the application:
-
-```jsx
-import { Routes, Route } from "@solidjs/router";
-
-export default function App() {
-	return (
-		<>
-			<h1>This is my site</h1>
-			<Routes>// Routes will go here</Routes>
-		</>
-	);
-}
-```
-
-2. The `Route` component takes a `path` prop, which specifies what path or element to render when navigated to.
-   When this path is successfully matched, the `component` or `element` prop will be triggered, rendering what it corresponds to.
-   For grouping multiple routes, or for nesting, the `Routes` component must be used.
-   For example:
+This will always be there and won't update on page change. It is the ideal place to put top level navigation and Context Providers.
 
 ```jsx
-import { Routes, Route } from "@solidjs/router";
+import { render } from "solid-js/web";
+import { Router, Route } from "@solidjs/router";
 
 import Home from "./pages/Home";
-import About from "./pages/About";
+import Users from "./pages/Users";
 
-export default function App() {
-	return (
-		<>
-			<h1>My Site with many pages</h1>
-			<Routes>
-				<Route path="/" component={Home} />
-				<Route path="/about" component={About} />
-				<Route path="/wow" element={<div>You can even do this!</div>} />
-			</Routes>
-		</>
-	);
-}
+const App = props => (
+  <>
+    <h1>My Site with lots of pages</h1>
+    {props.children}
+  </>
+)
+
+render(() => (
+  <Router root={App} />
+), document.getElementById("app"));
 ```
 
-## Creating links to Routes
+**4. Add routes to the `<Router>` component using the `Route` component**
 
-### The `A` Component
-
-The `A` component creates an anchor tag that navigates to routes within an application.
-Additionally, the component takes in an `href` prop which acts as the URL path that the link will navigate to.
+Add each route to a `Router` using the `Route` component. Specifying a path and a component to render when the user navigates to that path.
 
 ```jsx
-import { A } from "@solidjs/router";
+import { render } from "solid-js/web";
+import { Router, Route } from "@solidjs/router";
 
-export default function App() {
-	return (
-		<div>
-			<header>
-				<A href="/home">Home</A>
-				<A href="/about">About</A>
-			</header>
-		</div>
-	);
-}
-```
-
-The `A` component can also take in the `activeClass` prop, which is a class that will be applied when the current location matches the `href` prop.
-
-```jsx
-import { A } from "@solidjs/router";
-
-export default function App() {
-	return (
-		<div>
-			<header>
-				<p>
-					Edit <code>src/App.tsx</code> and save to reload.
-				</p>
-				<A href="/about">Home</A>
-				<A
-					href="/about"
-					activeClass="underlined" // when active, this link will now be underlined
-				>
-					About
-				</A>
-			</header>
-		</div>
-	);
-}
-```
-
-#### `A` Component Props
-
-| prop          | type                | description                                                                                                                                                                                                                                                                                                                                                     |
-| ------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| href          | string              | Indicates the URL path to navigate to, which must start with a forward slash ("/").                                                                                                                                                                                                                                                                             |
-| noScroll      | boolean             | If `true`, the default behavior of scrolling to the top of the new page will be turned off.                                                                                                                                                                                                                                                                     |
-| replace       | boolean             | If set to `true`, the new page will not be added to the browser history, preventing the back button from navigate to the previous route. By default, the new page is added to the browser history.                                                                                                                                                              |
-| state         | serializable object | Passes a serialized object to the history stack during navigation. When the user navigates to the new state, an event is triggered, granting access to a copy of the state object associated with that particular entry in the browsing history. See [`history.pushState()`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) for more info. |
-| inactiveClass | string              | Will specifies the CSS class to apply when the location and `href` prop do not match.                                                                                                                                                                                                                                                                           |
-| activeClass   | string              | The CSS class that will be applied when the location and `href` prop match.                                                                                                                                                                                                                                                                                     |
-| end           | boolean             | When set to `true`, the link is considered active only when the current location exactly matches the `href`. However, when set to `false`, the link is considered active if the current location _starts_ with the `href` value.                                                                                                                                |
-
-### The `Navigate` component
-
-Solid router offers a `Navigate` component that works similarly to `A`, however, it will _immediately_ navigate to the provided path as soon as the component is rendered.
-In addition to the `href` prop, there is an additional option to pass a function to `href` that returns a path to navigate to.
-
-```jsx
-function getPath({ navigate, location }) {
-	// `navigate` is the result of calling useNavigate();
-	// `location` is the result of calling useLocation().
-	// You can use those to dynamically determine a path to navigate to
-	return "/some-path";
-}
-
-//Navigating to /redirect will redirect you to the result of getPath
-<Route path="/redirect" element={<Navigate href={getPath} />} />;
-```
-
-## Nested Routes
-
-Solid Router supports nested routes, allowing for more complex routing structures.
-
-```jsx
-// Nested routes can be written as a single route
-<Route path="/about/me" component={User} />
-
-// Or they can be defined separately
-<Route path="/about">
-  <Route path="/me" component={User} />
-</Route>
-```
-
-However, only the innermost `Route` nodes will be given a route.
-To ensure the parent has its own route, it must be specified separately.
-
-```jsx
-// This will not work
-<Route path="/about" component={About}>
-  <Route path="/me" component={User} />
-</Route>
-
-// This will work
-<Route path="/about" component={About} />
-<Route path="/about/me" component={Me} />
-
-<Route path="/about">
-  <Route path="/" component={About} />
-  <Route path="/me" component={Me} />
-</Route>
-```
-
-### The `<Outlet />` Component
-
-Nested routes can also take advantage of the `<Outlet />` component to render the nested content within a parent component.
-The `<Outlet />` component serves as a placeholder that will be be replaced with the content of the matched child route.
-
-```jsx
-import { Outlet } from "@solidjs/router";
-
-function PageWrapper() {
-	return (
-		<div>
-			<h1>Solid is great!</h1>
-			<Outlet />
-			<A href="/">Back Home</A>
-		</div>
-	);
-}
-
-<Route path="/about" component={PageWrapper}>
-	<Route path="/" component={About} />
-	<Route path="/me" component={User} />
-</Route>;
-```
-
-In this example, the `<Outlet />` component is used to specify where the content of the child routes should be rendered within the `PageWrapper` component.
-When the `/about` route is matched, the `PageWrapper` component will be rendered, and the content of the child routes (`About` and `Me`) will be rendered inside the component.
-
-This approach allows you to define a **shared** layout or container component for a group of nested routes and render the specific element based on the child routes.
-As long as there are the appropriate parent component `<Outlet />` placeholders defined at each level, you can nest routes indefinitely using this approach.
-
-## Dynamic Routing
-
-Dynamic routing lets an application handle URLs where some segments are not known ahead of time.
-You can create a dynamic route by using a colon (:) before a segment in the `path` prop of a `Route` component.
-This indicates that the segment can be any string.
-
-```jsx
-import { Routes, Route } from "@solidjs/router";
 import Home from "./pages/Home";
-import About from "./pages/About";
-import User from "./pages/User";
+import Users from "./pages/Users";
 
-export default function App() {
-	return (
-		<>
-			<h1>My Site with many pages</h1>
-			<Routes>
-				<Route path="/" component={Home} />
-				<Route path="/about" component={About} />
-				<Route path="/user/:id" component={User} />
-				<Route path="/wow" element={<div>You can even do this!</div>} />
-			</Routes>
-		</>
-	);
-}
+render(() => (
+  <Router>
+    <Route path="/" component={Home} />
+    <Route path="/users" component={Users} />
+  </Router>
+), document.getElementById("app"));
 ```
 
-In the example above, the `:id` in the `/user/:id` path will be treated as a parameter.
-As long as the URL matches this pattern, the User component will be displayed.
+**5. Create a CatchAll Route (404 page)**
 
-### Accessing parameters
-
-In cases where you may need to access a dynamic route's parameters within your components, the `useParams` primitive is available.
-And once the parameters have been accessed using `useParams`, they can be used within your component:
+You can create catchall routes for pages not found at any nested level of the router. Use `*` and optionally the name of a parameter to retrieve the rest of the path.
 
 ```jsx
-import { useParams } from "@solidjs/router";
+import { render } from "solid-js/web";
+import { Router, Route } from "@solidjs/router";
 
-const User = () => {
-	const params = useParams(); // Retrieve the dynamic route parameters
-	// Now you can access the id parameter as params.id
+import Home from "./pages/Home";
+import Users from "./pages/Users";
+import NotFound from "./pages/404";
 
-	return (
-		<p>
-			This is the user with the id of <code>{params.id}</code>
-		</p>
-	);
-};
+const App = props => (
+  <>
+    <h1>My Site with lots of pages</h1>
+    {props.children}
+  </>
+)
+
+render(() => (
+  <Router root={App}>
+    <Route path="/" component={Home} />
+    <Route path="/users" component={Users} />
+    <Route path="*404" component={NotFound} />
+  </Router>
+), document.getElementById("app"));
 ```
 
-This primtive can be especially useful with other Solid primitives, such as [`createResource`](/reference/basic-reactivity/create-resource) and [`createSignal`](/reference/basic-reactivity/create-signal), which can create dynamic behaviours based on the route parameters.
+**6. Create Links to Your Routes**
 
-```jsx
-import { createResource } from "solid-js";
-import { useParams } from "@solidjs/router";
-
-async function fetchUser(id) {
-	const response = await fetch(
-		`https://jsonplaceholder.typicode.com/users/${id}`
-	);
-	return response.json();
-}
-
-const User = () => {
-	const params = useParams();
-	const [data] = createResource(params.id, fetchUser); // Pass the id parameter to createResource
-
-	return (
-		<div>
-			{data.loading ? (
-				<p>Loading...</p>
-			) : (
-				<div>
-					<p>Name: {data().name}</p>
-					<p>Email: {data().email}</p>
-					<p>Phone: {data().phone}</p>
-				</div>
-			)}
-		</div>
-	);
-};
-```
-
-Every time the `id` parameter changes in this example, the `fetchUser` function is called to fetch the new user data.
-
-### Validating routes
-
-When working with dynamic routes, it is often necessary to validate the route parameters to ensure they meet certain criteria.
-This task can be performed through `MatchFilters`.
-
-`MatchFilters` provides the option to define validation rules for each parameter in the route path.
-By including the `matchFilters={filters}` prop in the `<Route>` component, the parameters in the route path are automatically validated against their respective filters.
-If any validation fails, the route will not be matched.
-
-```jsx
-//...
-const filters: MatchFilters = {
-	parent: ["mom", "dad"], // allow enum values
-	id: /^\d+$/, // only allow numbers
-	withHtmlExtension: (v: string) => v.length > 5 && v.endsWith(".html"), // custom validation function
-};
-
-export default function App() {
-	// ...
-	return (
-		<>
-			<h1>My Site with Lots of Pages</h1>
-			<Routes>
-				<Route
-					path="/users/:id/:/parent/:withHtmlExtension"
-					component={User}
-					matchFilters={filters}
-				/>
-			</Routes>
-		</>
-	);
-}
-```
-
-In this example, the `filters` object defines the validation rules for each parameter:
-
-- The `parent` parameter allows only the values `"mom"` or `"dad"` .
-- The `id` parameter allows only numeric values.
-- The `withHtmlExtension` parameter is validated using a custom function that checks for a length greater than 5 and a `".html"` extension.
-
-<EraserLink
-	href="https://app.eraser.io/workspace/maDvFw5OryuPJOwSLyK9?elements=jd9aj0AajuFLhKTxNXbEbQ"
-	preview="https://app.eraser.io/workspace/maDvFw5OryuPJOwSLyK9/preview?elements=jd9aj0AajuFLhKTxNXbEbQ&type=embed"
-/>
-
-### Creating optional routes
-
-Routes can be specified as optional by adding `?` to the end of a parameter name for more flexible routing patterns.
-This is especially useful when specific segments of the path may or may not be present.
-
-```jsx
-<Route path="/stories/:id?" element={<Stories />} />
-```
-
-### Specifying wildcard routes
-
-Wildcard routes allow matching of any descendent within a given path.
-The wildcard token (`*`) can be used to represent any value in that segment of the path.
-Additionally, this value can be exposed as a parameter to the component.
-
-```jsx
-<Route path="foo/*" component={Foo} />
-```
-
-In this example, the route path `"foo/*"` matches any path that begins with `"foo"`.
-This includes paths like `"foo/"`, `"foo/a/"`, or `"foo/a/b/c"`.
-
-To expose the wildcard part of the path to the component as a parameter, you can do the following:
-
-```jsx
-<Route path="foo/*any" element={<div>{useParams().any}</div>} />
-```
-
-**Note**: The wildcard token must be the last part of the path; `foo/*any/bar` would not create any routes.
-
-## Defining Multiple Paths
-
-Routes can be defined with multiple paths using an array.
-This feature allows a `Route` component to **remain mounted** and avoid re-rendering when switching between multiple locations that match any of the predetermined paths.
-Using multiple paths can be useful when the same component and state are to be shared between different URLs that serve a similar purpose.
-
-```jsx
-<Route path={["login", "register"]} component={Login} />
-```
-
-## Creating data components
-
-Solid Router also supports data components, which are components that fetch and manage data for a specific route.
-These components offer a declarative and reusable approach to handling data fetching within routes.
-
-To create a data component, you can define a component that fetches and manages data, and then pass it as the `data` prop to the `Route` component.
-This function is then passed to the `data` prop of the `Route` component, initiating the data fetching in parallel with the page load.
-In doing this, the data is available as soon as possible, reducing any delays that people may experience.
-
-```jsx
-import UserData from "./pages/users/[id].data.js";
-const User = lazy(() => import("/pages/users/[id].js"));
-
-// In the Route definition
-<Route path="/users/:id" component={User} data={UserData} />;
-```
-
-Once the data component is set up, the fetched data can be accessed within the route component by using the `useRouteData` hook.
-This utility allows you to retrieve the results of the `data` function once the route is loaded.
-
-```jsx
-// Inside the route component
-const data = useRouteData();
-```
-
-This data function receives an object as its argument, containing valuable route information, including:
-
-| Key        | Type                                              | Description                                                                                                            |
-| ---------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `params`   | object                                            | The route parameters (same value as calling useParams() inside the route component)                                    |
-| `location` | `{ pathname, search, hash, query, state, key}`    | An object that you can use to get more information about the path (corresponds to [useLocation()](#uselocation))       |
-| `navigate` | `(to: string, options?: NavigateOptions) => void` | A function that you can call to navigate to a different route instead (corresponds to [useNavigate()](#usenavigation)) |
-| `data`     | unknown                                           | The data returned by the parent's data function, if any. (Data will pass through any intermediate nesting.)            |
-
-### Organizing data functions
-
-A possible way to use this is through exporting the data function of the corresponding route into a dedicated `route.data.js` or `route.data.ts` file.
-This imports the data functions independently, without loading any additional resources.
-
-```jsx
-  import { lazy } from "solid-js";
-  import { Route } from "@solidjs/router";
-- import { fetchUser } ...
-+ import UserData from "./pages/users/[id].data.js";
-  const User = lazy(() => import("/pages/users/[id].js"));
-
-  // In the Route definition
-  <Route path="/users/:id" component={User} data={UserData} />;
-```
-
-Using this pattern means there is no need to import the `fetchUser` function directly in the route component since it will be encapsulated within the `[id].data.js` file.
-
-## Hash-based routing mode
-
-The default behaviour in Solid Router is to use `location.pathname` to find the route path.
-However, there is more flexibility built into the router which gives you the option to easily switch to hash mode through the `source` property in the `<Router>` component.
-
-```jsx
-import { Router, hashIntegration } from "@solidjs/router";
-<Router source={hashIntegration()}>
-	<App />
-</Router>;
-```
-
-This adjustment tells your application to use the URL hash to manage routes, which can be useful for ensuring compatability with browsers that do not support the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) or for serving static files.
-
-## Config-based routing
-
-Defining routes in Solid does not always require the use of JSX.
-An alternative approach is to use a configuration object to define your routes.
-This method is helpful when you aim to define your routes in a separate file, import them into your app, and then pass them to the `useRoutes` function.
+Use the `A` component to provide navigation to the application's routes. Alternatively, you can use an anchor tag. However, the `A` component has additional functionality including properties for CSS `inactiveClass` and `activeClass`.
 
 ```jsx
 import { lazy } from "solid-js";
 import { render } from "solid-js/web";
-import { Router, useRoutes, A } from "@solidjs/router";
+import { Router, Route } from "@solidjs/router";
 
-// Define your routes using a config object
-const routes = [
-	{
-		path: "/users",
-		component: lazy(() => import("/pages/users.js")),
-	},
-	{
-		path: "/users/:id",
-		component: lazy(() => import("/pages/users/[id].js")),
-		children: [
-			{
-				path: "/",
-				component: lazy(() => import("/pages/users/[id]/index.js")),
-			},
-			{
-				path: "/settings",
-				component: lazy(() => import("/pages/users/[id]/settings.js")),
-			},
-			{
-				path: "/*all",
-				component: lazy(() => import("/pages/users/[id]/[...all].js")),
-			},
-		],
-	},
-	{
-		path: "/",
-		component: lazy(() => import("/pages/index.js")),
-	},
-	{
-		path: "/*all",
-		component: lazy(() => import("/pages/[...all].js")),
-	},
-];
+import Home from "./pages/Home";
+import Users from "./pages/Users";
 
-function App() {
-	// useRoutes function takes in the routes config
-	const Routes = useRoutes(routes);
-	return (
-		<>
-			<h1>Awesome Site</h1>
-			<A class="nav" href="/">
-				Home
-			</A>
-			<A class="nav" href="/users">
-				Users
-			</A>
-			<Routes />
-		</>
-	);
+const App = props => (
+  <>
+    <nav>
+      ** SHOULD I BE USING <A> HERE?
+      <a href="/">Home</a>
+      <a href="/">Users</a>
+    </nav>
+    <h1>My Site with lots of pages</h1>
+    {props.children}
+  </>
+);
+
+render(() => (
+   <Router root={App}>
+     <Route path="/" component={Home} />
+     <Route path="/users" component={Users} />
+     <Route path="*404" component={NotFound} />
+  </Router>
+), document.getElementById("app"));
+```
+
+## Lazy-loading Route Components
+
+This way, the `Users` and `Home` components will only be loaded if you're navigating to `/users` or `/`, respectively.
+
+```jsx
+import { lazy } from "solid-js";
+import { render } from "solid-js/web";
+import { Router, Route } from "@solidjs/router";
+
+const Users = lazy(() => import("./pages/Users"));
+const Home = lazy(() => import("./pages/Home"));
+
+const App = props => (
+  <>
+    <h1>My Site with lots of pages</h1>
+    {props.children}
+  </>
+)
+
+render(() => (
+  <Router root={App}>
+    <Route path="/users" component={Users} />
+    <Route path="/" component={Home} />
+  </Router>
+), document.getElementById("app"));
+```
+
+## Dynamic Routes
+
+If you don't know the path ahead of time, you might want to treat part of the path as a flexible parameter that is passed on to the component.
+
+```jsx
+import { lazy } from "solid-js";
+import { render } from "solid-js/web";
+import { Router, Route } from "@solidjs/router";
+
+const Users = lazy(() => import("./pages/Users"));
+const User = lazy(() => import("./pages/User"));
+const Home = lazy(() => import("./pages/Home"));
+
+render(() => (
+  <Router>
+    <Route path="/users" component={Users} />
+    <Route path="/users/:id" component={User} />
+    <Route path="/" component={Home} />
+  </Router>
+ ), document.getElementById("app"));
+```
+
+The colon indicates that `id` can be any string, and as long as the URL fits that pattern, the `User` component will show.
+
+You can then access that `id` from within a route component with `useParams`.
+
+**Note on Animation/Transitions**:
+Routes that share the same path match will be treated as the same route. If you want to force re-render you can wrap your component in a keyed `<Show>` like:
+```jsx
+<Show when={params.something} keyed><MyComponent></Show>
+```
+---
+
+Each path parameter can be validated using a `MatchFilter`.
+This allows for more complex routing descriptions than just checking the presence of a parameter.
+
+```jsx
+import { lazy } from "solid-js";
+import { render } from "solid-js/web";
+import { Router, Route } from "@solidjs/router";
+import type { SegmentValidators } from "./types";
+
+const User = lazy(() => import("./pages/User"));
+
+const filters: MatchFilters = {
+  parent: ["mom", "dad"], // allow enum values
+  id: /^\d+$/, // only allow numbers
+  withHtmlExtension: (v: string) => v.length > 5 && v.endsWith(".html"), // we want an `*.html` extension
+};
+
+render(() => (
+  <Router>
+    <Route
+      path="/users/:parent/:id/:withHtmlExtension"
+      component={User}
+      matchFilters={filters}
+    />
+  </Router>
+), document.getElementById("app"));
+```
+
+Here, we have added the `matchFilters` prop. This allows us to validate the `parent`, `id` and `withHtmlExtension` parameters against the filters defined in `filters`.
+If the validation fails, the route will not match.
+
+So in this example:
+
+- `/users/mom/123/contact.html` will match,
+- `/users/dad/123/about.html` will match,
+- `/users/aunt/123/contact.html` will not match as `:parent` is not 'mom' or 'dad',
+- `/users/mom/me/contact.html` will not match as `:id` is not a number,
+- `/users/dad/123/contact` will not match as `:withHtmlExtension` is missing `.html`.
+
+---
+
+### Optional Parameters
+
+Parameters can be specified as optional by adding a question mark to the end of the parameter name:
+
+```jsx
+// Matches stories and stories/123 but not stories/123/comments
+<Route path="/stories/:id?" component={Stories} />
+```
+
+### Wildcard Routes
+
+`:param` lets you match an arbitrary name at that point in the path. You can use `*` to match any end of the path:
+
+```jsx
+// Matches any path that begins with foo, including foo/, foo/a/, foo/a/b/c
+<Route path="foo/*" component={Foo} />
+```
+
+If you want to expose the wild part of the path to the component as a parameter, you can name it:
+
+```jsx
+<Route path="foo/*any" component={Foo} />
+```
+
+Note that the wildcard token must be the last part of the path; `foo/*any/bar` won't create any routes.
+
+### Multiple Paths
+
+The `Routes` component also supports defining multiple paths using an array. This allows a route to remain mounted and not rerender when switching between two or more locations that it matches:
+
+```jsx
+// Navigating from login to register does not cause the Login component to re-render
+<Route path={["login", "register"]} component={Login} />
+```
+
+## Nested Routes
+
+The following two route definitions have the same result:
+
+```jsx
+<Route path="/users/:id" component={User} />
+```
+
+```jsx
+<Route path="/users">
+  <Route path="/:id" component={User} />
+</Route>
+```
+
+`/users/:id` renders the `<User/>` component, and `/users/` is an empty route.
+
+Only leaf Route nodes (innermost `Route` components) are given a route. If you want to make the parent its own route, you have to specify it separately:
+
+```jsx
+//This won't work the way you'd expect
+<Route path="/users" component={Users}>
+  <Route path="/:id" component={User} />
+</Route>
+
+// This works
+<Route path="/users" component={Users} />
+<Route path="/users/:id" component={User} />
+
+// This also works
+<Route path="/users">
+  <Route path="/" component={Users} />
+  <Route path="/:id" component={User} />
+</Route>
+```
+
+You can also take advantage of nesting by using `props.children` passed to the route component.
+
+```jsx
+function PageWrapper(props) {
+  return (
+    <div>
+      <h1> We love our users! </h1>
+      {props.children}
+      <A href="/">Back Home</A>
+    </div>
+  );
 }
 
-render(
-	() => (
-		<Router>
-			<App />
-		</Router>
-	),
-	document.getElementById("app")
+<Route path="/users" component={PageWrapper}>
+  <Route path="/" component={Users} />
+  <Route path="/:id" component={User} />
+</Route>;
+```
+
+The routes are still configured the same, but now the route components will appear inside the parent component where the `props.children` was declared.
+
+You can nest indefinitely - just remember that only leaf nodes will become their own routes. In this example, the only route created is `/layer1/layer2`, and it appears as three nested divs.
+
+```jsx
+<Route
+  path="/"
+  component={(props) =>
+    <div>
+      Onion starts here {props.children}
+    </div>
+  }
+>
+  <Route
+    path="layer1"
+    component={(props) =>
+      <div>
+        Another layer {props.children}
+      </div>
+    }
+  >
+    <Route path="layer2"
+      component={() => <div>Innermost layer</div>}>           </Route>
+  </Route>
+</Route>
+```
+
+## Load Functions
+
+Even with smart caches it is possible that we have waterfalls both with view logic and with lazy loaded code. With load functions, we can instead start fetching the data parallel to loading the route, so we can use the data as soon as possible. The load function is called when the Route is loaded or eagerly when links are hovered.
+
+As its only argument, the load function is passed an object that you can use to access route information:
+
+```js
+import { lazy } from "solid-js";
+import { Route } from "@solidjs/router";
+
+const User = lazy(() => import("./pages/users/[id].js"));
+
+// load function
+function loadUser({params, location}) {
+  // do loading
+}
+
+// Pass it in the route definition
+<Route path="/users/:id" component={User} load={loadUser} />;
+```
+
+| key      | type                                              | description                                                                                                                   |
+| -------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| params   | object                                            | The route parameters (same value as calling `useParams()` inside the route component)                                         |
+| location | `{ pathname, search, hash, query, state, key}`    | An object that you can use to get more information about the path (corresponds to [`useLocation()`](#uselocation))        |
+| intent | `"initial", "navigate", "native", "preload"` | Indicates why this function is being called. <ul><li>"initial" - the route is being initially shown (ie page load)</li><li>"native" - navigate originated from the browser (eg back/forward)</li><li>"navigate" - navigate originated from the router (eg call to navigate or anchor clicked)</li><li>"preload" - not navigating, just preloading (eg link hover)</li></ul> |
+
+
+A common pattern is to export the load function and data wrappers that corresponds to a route in a dedicated `route.data.js` file. This way, the data function can be imported without loading anything else.
+
+```js
+import { lazy } from "solid-js";
+import { Route } from "@solidjs/router";
+import loadUser from "./pages/users/[id].data.js";
+const User = lazy(() => import("/pages/users/[id].js"));
+
+// In the Route definition
+<Route path="/users/:id" component={User} load={loadUser} />;
+```
+
+The return value of the `load` function is passed to the page component when called at anytime other than `"preload"`, so you can initialize things in there, or alternatively use our new Data APIs:
+
+## Data APIs
+
+Keep in mind these are completely optional, but showcase the power of our load mechanism.
+
+### `cache`
+
+To prevent duplicate fetching and to trigger handle refetching we provide a cache API. That takes a function and returns the same function.
+
+```jsx
+const getUser = cache((id) => {
+  return (await fetch(`/api/users${id}`)).json()
+}, "users") // used as cache key + serialized arguments
+```
+It is expected that the arguments to the cache function are serializable.
+
+This cache accomplishes the following:
+
+1. It does just deduping on the server for the lifetime of the request.
+2. It does preload cache in the browser which lasts 10 seconds. When a route is preloaded on hover or when load is called when entering a route, it will make sure to dedupe calls.
+3. We have a reactive refetch mechanism based on key. So we can tell routes that aren't new to retrigger on action revalidation.
+4. It will serve as a back/forward cache for browser navigation up to 5 mins. Any user based navigation or link click bypasses it. Revalidation or new fetch updates the cache.
+
+Using it with the load function might look like:
+
+```js
+import { lazy } from "solid-js";
+import { Route } from "@solidjs/router";
+import { getUser } from ... // the cache function
+
+const User = lazy(() => import("./pages/users/[id].js"));
+
+// load function
+function loadUser({params, location}) {
+  void getUser(params.id)
+}
+
+// Pass it in the route definition
+<Route path="/users/:id" component={User} load={loadUser} />;
+```
+
+Inside your page component you:
+
+```jsx
+// pages/users/[id].js
+import { getUser } from ... // the cache function
+
+export default function User(props) {
+  const user = createAsync(() => getUser(props.params.id));
+  return <h1>{user().name}</h1>;
+}
+```
+
+Cached function has a few useful methods for getting the key that are useful for invalidation.
+
+```ts
+let id = 5;
+
+getUser.key // returns "users"
+getUser.keyFor(id) // returns "users[5]"
+```
+
+You can revalidate the cache using the `revalidate` method or you can set `revalidate` keys on your response from your actions. If you pass the whole key it will invalidate all the entries for the cache (ie "users" in the example above). You can also invalidate a single entry by using `keyFor`.
+
+`cache` can be defined anywhere and then used inside your components with:
+
+### `createAsync`
+
+This is a light wrapper over `createResource` which aims to serve as a stand-in for a future primitive we intend to bring to Solid core in 2.0. It is a simpler async primitive where the function tracks like `createMemo` and it expects a promise back that it turns into a Signal. Reading it before it is ready causes Suspense/Transitions to trigger.
+
+```jsx
+const user = createAsync((currentValue) => getUser(params.id))
+```
+
+Using `cache` in `createResource` directly won't work properly as the fetcher is not reactive and it won't invalidate properly.
+
+### `action`
+
+Actions are data mutations that can trigger invalidations and further routing. A list of prebuilt response helpers can be found below.
+```jsx
+import { action, revalidate, redirect } from "@solidjs/router"
+
+// anywhere
+const myAction = action(async (data) => {
+  await doMutation(data);
+  throw redirect("/", { revalidate: getUser.keyFor(data.id) }); // throw a response to do a redirect
+});
+
+// in component
+<form action={myAction} method="post" />
+
+//or
+<button type="submit" formaction={myAction}></button>
+```
+
+Actions only work with post requests, so make sure to put `method="post"` on your form.
+
+Sometimes it might be easier to deal with typed data instead of `FormData` and adding additional hidden fields. For that reason, Actions have a `with` method that works similar to `bind`, which applies the arguments in order.
+
+Picture an action that deletes Todo Item:
+
+```js
+const deleteTodo = action(async (formData: FormData) => {
+  const id = Number(formData.get("id"))
+  await api.deleteTodo(id)
+})
+
+<form action={deleteTodo} method="post">
+  <input type="hidden" name="id" value={todo.id} />
+  <button type="submit">Delete</button>
+</form>
+```
+Instead, with `with` you can write this:
+```js
+const deleteUser = action(api.deleteTodo)
+
+<form action={deleteTodo.with(todo.id)} method="post">
+  <button type="submit">Delete</button>
+</form>
+```
+
+#### Notes of `<form>` implementation and SSR
+This requires stable references as you can only serialize a string as an attribute, and across SSR they'd need to match. The solution is providing a unique name.
+
+```jsx
+const myAction = action(async (args) => {}, "my-action");
+```
+
+### `useAction`
+
+Instead of forms, you can use actions directly by wrapping them in a `useAction` primitive. This is how we get the router context.
+
+```jsx
+// in component
+const submit = useAction(myAction)
+submit(...args)
+```
+
+Outside of a form context you can use custom data instead of formData, and these helpers preserve types. However, even when used with server functions (in projects like SolidStart) this requires client-side JavaScript and is not Progressive Enhancible like forms are.
+
+### `useSubmission`/`useSubmissions`
+
+These are used for injecting the optimistic updates while actions are in flight. They either return a single Submission(latest) or all that match with an optional filter function.
+
+```jsx
+type Submission<T, U> = {
+  readonly input: T;
+  readonly result?: U;
+  readonly pending: boolean;
+  readonly url: string;
+  clear: () => void;
+  retry: () => void;
+};
+
+const submissions = useSubmissions(action, (input) => filter(input));
+const submission = useSubmission(action, (input) => filter(input));
+```
+
+### Response Helpers
+
+These are used to communicate router navigations from cache/actions, and can include invalidation hints. Generally, these are thrown to not interfere the with the types and make it clear that function ends execution at that point.
+
+#### `redirect(path, options)`
+
+Redirects to the next route
+```js
+const getUser = cache(() => {
+  const user = await api.getCurrentUser()
+  if (!user) throw redirect("/login");
+  return user;
+})
+```
+
+#### `reload(options)`
+
+Reloads the data on the current page
+```js
+const getTodo = cache(async (id: number) => {
+  const todo = await fetchTodo(id);
+  return todo;
+}, "todo")
+
+const updateTodo = action(async (todo: Todo) => {
+  await updateTodo(todo.id, todo);
+  reload({ revalidate: getTodo.keyFor(id) })
+})
+```
+
+## Config Based Routing
+
+You don't have to use JSX to set up your routes; you can pass an array of route definitions:
+
+```jsx
+import { lazy } from "solid-js";
+import { render } from "solid-js/web";
+import { Router } from "@solidjs/router";
+
+const routes = [
+  {
+    path: "/users",
+    component: lazy(() => import("/pages/users.js")),
+  },
+  {
+    path: "/users/:id",
+    component: lazy(() => import("/pages/users/[id].js")),
+    children: [
+      {
+        path: "/",
+        component: lazy(() => import("/pages/users/[id]/index.js")),
+      },
+      {
+        path: "/settings",
+        component: lazy(() => import("/pages/users/[id]/settings.js")),
+      },
+      {
+        path: "/*all",
+        component: lazy(() => import("/pages/users/[id]/[...all].js")),
+      },
+    ],
+  },
+  {
+    path: "/",
+    component: lazy(() => import("/pages/index.js")),
+  },
+  {
+    path: "/*all",
+    component: lazy(() => import("/pages/[...all].js")),
+  },
+];
+
+render(() =>
+  <Router>{routes}</Router>,
+  document.getElementById("app")
 );
 ```
 
-In this example, the `routes` config object contains the definitions for various routes and their respective components.
-The `useRoutes` function then takes the configuration object and generates the corresponding routes for the application.
-
-## Solid Route primitives
-
-Solid Router offers a variety of primitives that interact with the Router and Route context.
-These primitives provide functionalities such as retrieving route parameters, navigating between routes, and accessing location information.
-
-### `useParams`
-
-The `useParams` primitive retrieves a reactive object containing the current route path paramteres as defined in the Route.
+Also, you can pass a single route definition object for a single route:
 
 ```jsx
-import { useParams } from "@solidjs/router";
+import { lazy } from "solid-js";
+import { render } from "solid-js/web";
+import { Router } from "@solidjs/router";
 
+const route = {
+  path: "/",
+  component: lazy(() => import("/pages/index.js"))
+};
+
+render(() => <Router>{route}</Router>, document.getElementById("app"));
+```
+
+## Alternative Routers
+
+### Hash Mode Router
+
+By default, Solid Router uses `location.pathname` as the route path. You can simply switch to hash mode by using `<`HashRouter>`.
+
+```jsx
+import { HashRouter } from "@solidjs/router";
+
+<HashRouter />;
+```
+
+### Memory Mode Router
+
+You can also use memory mode router for testing purposes.
+
+```jsx
+import { MemoryRouter } from "@solidjs/router";
+
+<MemoryRouter />;
+```
+
+### SSR Routing
+
+For SSR you can use the static router directly or the browser Router defaults to it on the server, just pass in the URL.
+
+```jsx
+import { isServer } from "solid-js/web";
+import { Router } from "@solidjs/router";
+
+<Router url={isServer ? req.url : ""} />;
+```
+
+
+## Components
+
+### `<Router>`
+
+This is the main Router component for the browser.
+
+| prop | type | description |
+|-----|----|----|
+| children | `JSX.Element`, `RouteDefinition`, or `RouteDefinition[]` | The route definitions |
+| root | Component | Top level layout component |
+| base | string | Base url to use for matching routes |
+| actionBase | string | Root url for server actions, default: `/_server` |
+| preload | boolean | Enables/disables preloads globally, default: `true` |
+| explicitLinks | boolean | Disables all anchors being intercepted and instead requires `<A>`. default: `false` |
+
+### `<A>`
+
+Like the `<a>` tag but supports automatic application of base path + relative paths and active class styling (requires client-side JavaScript).
+
+The `<A>` tag has an `active` class if its href matches the current location, and `inactive` otherwise. **Note**:** By default, matching includes locations that are descendants (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these. This is particularly useful for links to the root route `/` which would match everything.
+
+| prop          |  type   | description                                                                                                                                                                              |
+| ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| href          | string  | The path of the route to navigate to. This will be resolved relative to the route that the link is in, but you can preface it with `/` to refer back to the root.                        |
+| noScroll      | boolean | If true, turn off the default behavior of scrolling to the top of the new page                                                                                                           |
+| replace       | boolean | If true, don't add a new entry to the browser history. (By default, the new page will be added to the browser history, so pressing the back button will take you to the previous route.) |
+| state         | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating                                                               |
+| inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link)                                                                                           |
+| activeClass   | string  | The class to show when the link is active                                                                                                                                                |
+| end           | boolean | If `true`, only considers the link to be active when the curent location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                      |
+
+### `<Navigate />`
+
+Solid Router provides a `Navigate` component that works similarly to `A`, but it will _immediately_ navigate to the provided path as soon as the component is rendered. It also uses the `href` prop, but you have the additional option of passing a function to `href` that returns a path to navigate to:
+
+```jsx
+function getPath({ navigate, location }) {
+  // navigate is the result of calling useNavigate(); location is the result of calling useLocation().
+  // You can use those to dynamically determine a path to navigate to
+  return "/some-path";
+}
+
+// Navigating to /redirect will redirect you to the result of getPath
+<Route path="/redirect" component={() => <Navigate href={getPath} />} />;
+```
+
+### `<Route>`
+
+The Component for defining Routes:
+
+| prop | type | description |
+|-|-|-|
+| path | string | Path partial for defining the route segment |
+| component | `Component` | Component that will be rendered for the matched segment |
+| matchFilters | `MatchFilters` | Additional constraints for matching against the route |
+| children | `JSX.Element` | Nested `<Route>` definitions |
+| load | `RouteLoadFunc` | Function called during preload or when the route is navigated to. |
+
+## Router Primitives
+
+Solid Router provides several primitives that read off the Router and Route context.
+
+### useParams
+
+Retrieves a reactive, store-like object containing the current route path parameters as defined in the Route.
+
+```js
 const params = useParams();
 
-// Fetch user based on the id path parameter
+// fetch user based on the id path parameter
 const [user] = createResource(() => params.id, fetchUser);
 ```
 
-### `useNavigate`
+### useNavigate
 
-`useNavigate` provides a method for imperative navigation.
-It returns a `navigate` function that accepts a path and an optional options object, allowing for customized navigation behavior.
+Retrieves method to do navigation. The method accepts a path to navigate to and an optional object with the following options:
 
-```jsx
+- resolve (_boolean_, default `true`): resolve the path against the current route
+- replace (_boolean_, default `false`): replace the history entry
+- scroll (_boolean_, default `true`): scroll to top after navigation
+- state (_any_, default `undefined`): pass custom state to `location.state`
+
+**Note:** The state is serialized using the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) which does not support all object types.
+
+```js
 const navigate = useNavigate();
 
 if (unauthorized) {
-	navigate("/login", { replace: true });
+  navigate("/login", { replace: true });
 }
 ```
 
-The available options include:
+### useLocation
 
-- `resolve` (_boolean_, default `true`): Resolve the path against the current route.
-- `replace` (_boolean_, default `false`): Replace the history entry.
-- `scroll` (_boolean_, default `true`): Scroll to top after navigation.
-- `state` (_any_, default `undefined`): Pass custom state to `location.state`.
+Retrieves reactive `location` object useful for getting things like `pathname`
 
-<Callout>
-	The state is serialized using the [structured clone algorithm](
-	https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm),
-	which does not support all object types.
-</Callout>
-
-### `useLocation`
-
-`useLocation` retrieves a reactive location object, which is useful for accessing properties like `pathname`, `search`, `hash`, `state`, etc.
-
-```jsx
-import { useLocation } from "@solidjs/router";
-
+```js
 const location = useLocation();
 
-const pathname = createMemo(() => location.pathname);
+const pathname = createMemo(() => parsePath(location.pathname));
 ```
 
-### `useSearchParams`
+### useSearchParams
 
-`useSearchParams` returns a destructured array that contains a reactive object to read the current location's query parameters and a method to update them.
-The setter method merges the entries into the current query string, and updates behave like a navigation.
+Retrieves a tuple containing a reactive object to read the current location's query parameters and a method to update them. The object is a proxy so you must access properties to subscribe to reactive updates. Note values will be strings and property names will retain their casing.
 
-```jsx
+The setter method accepts an object whose entries will be merged into the current query string. Values `''`, `undefined` and `null` will remove the key from the resulting query string. Updates will behave just like a navigation and the setter accepts the same optional second parameter as `navigate` and auto-scrolling is disabled by default.
+
+```js
 const [searchParams, setSearchParams] = useSearchParams();
 
 return (
-	<div>
-		<span>Page: {searchParams.page}</span>
-		<button onClick={() => setSearchParams({ page: searchParams.page + 1 })}>
-			Next Page
-		</button>
-	</div>
-);
-```
-
-### `useIsRouting`
-
-`useIsRouting` retrieves a signal indicating whether the route is currently in a Transition.
-This is useful for displaying stale/pending states during concurrent rendering.
-
-```jsx
-Copy code
-const isRouting = useIsRouting();
-
-return (
-  <div classList={{ "grey-out": isRouting() }}>
-    <MyAwesomeContent />
+  <div>
+    <span>Page: {searchParams.page}</span>
+    <button
+      onClick={() =>
+        setSearchParams({ page: (parseInt(searchParams.page) || 0) + 1 })
+      }
+    >
+      Next Page
+    </button>
   </div>
 );
 ```
 
-### `useRouteData`
+### useIsRouting
 
-`useRouteData` retrieves the return value from the data function.
+Retrieves signal that indicates whether the route is currently in a Transition. Useful for showing stale/pending state when the route resolution is Suspended during concurrent rendering.
 
-```jsx
-import { useRouteData } from "@solidjs/router";
+```js
+const isRouting = useIsRouting();
 
-const user = useRouteData();
-
-return <h1>{user().name}</h1>;
+return (
+  <div classList={{ "grey-out": isRouting() }}>
+    <MyAwesomeConent />
+  </div>
+);
 ```
 
-### `useMatch`
+### useMatch
 
-`useMatch` creates a [Memo](/concepts/derived-values/memos) that returns match information if the current path matches the provided path, which is useful for determining if a given path matches the current route.
+`useMatch` takes an accessor that returns the path and creates a Memo that returns match information if the current path matches the provided path. Useful for determining if a given path matches the current route.
 
-```jsx
+```js
 const match = useMatch(() => props.href);
 
 return <div classList={{ active: Boolean(match()) }} />;
 ```
 
-### `useRoutes`
+### useBeforeLeave
 
-`useRoutes` is used to define routes via a config object instead of JSX.
-See [Config-Based Routing](#config-based-routing) for more details.
+`useBeforeLeave` takes a function that will be called prior to leaving a route. The function will be called with:
 
-### `useBeforeLeave`
+- from (_Location_): current location (before change).
+- to (_string | number_}: path passed to `navigate`.
+- options (_NavigateOptions_}: options passed to `navigate`.
+- preventDefault (_void function_): call to block the route change.
+- defaultPrevented (_readonly boolean_): true if any previously called leave handlers called preventDefault().
+- retry (_void function_, _force?: boolean_ ): call to retry the same navigation, perhaps after confirming with the user. Pass `true` to skip running the leave handlers again (ie force navigate without confirming).
 
-`useBeforeLeave` takes a function that will be called prior to leaving a route, providing various parameters and methods to manage route changes.
+Example usage:
 
-```jsx
+```js
 useBeforeLeave((e: BeforeLeaveEventArgs) => {
-	if (form.isDirty && !e.defaultPrevented) {
-		e.preventDefault();
-		setTimeout(() => {
-			if (window.confirm("Discard unsaved changes - are you sure?")) {
-				e.retry(true);
-			}
-		}, 100);
-	}
+  if (form.isDirty && !e.defaultPrevented) {
+    // preventDefault to block immediately and prompt user async
+    e.preventDefault();
+    setTimeout(() => {
+      if (window.confirm("Discard unsaved changes - are you sure?")) {
+        // user wants to proceed anyway so retry with force=true
+        e.retry(true);
+      }
+    }, 100);
+  }
 });
 ```
+
+## Migrations from 0.9.x
+
+v0.10.0 brings some big changes to support the future of routing including Islands/Partial Hydration hybrid solutions. Most notably there is no Context API available in non-hydrating parts of the application.
+
+The biggest changes are around removed APIs that need to be replaced.
+
+### `<Outlet>`, `<Routes>`, `useRoutes`
+
+This is no longer used and instead will use `props.children` passed from into the page components for outlets. This keeps the outlet directly passed from its page and avoids oddness of trying to use context across Islands boundaries. Nested `<Routes>` components inherently cause waterfalls and are `<Outlets>` themselves so they have the same concerns.
+
+Keep in mind no `<Routes>` means the `<Router>` API is different. The `<Router>` acts as the `<Routes>` component and its children can only be `<Route>` components. Your top-level layout should go in the root prop of the router [as shown above](#configure-your-routes)
+
+## `element` prop removed from `Route`
+
+Related without Outlet component it has to be passed in manually. At which point the `element` prop has less value. Removing the second way to define route components to reduce confusion and edge cases.
+
+### `data` functions & `useRouteData`
+
+These have been replaced by a load mechanism. This  allows link hover preloads (as the load function can be run as much as wanted without worry about reactivity). It supports deduping/cache APIs which give more control over how things are cached. It also addresses TS issues with getting the right types in the Component without `typeof` checks.
+
+That being said you can reproduce the old pattern largely by turning off preloads at the router level and then injecting your own Context:
+
+```js
+import { lazy } from "solid-js";
+import { Route } from "@solidjs/router";
+
+const User = lazy(() => import("./pages/users/[id].js"));
+
+// load function
+function loadUser({params, location}) {
+  const [user] = createResource(() => params.id, fetchUser);
+  return user;
+}
+
+// Pass it in the route definition
+<Router preload={false}>
+  <Route path="/users/:id" component={User} load={loadUser} />
+</Router>
+```
+
+And then in your component taking the page props and putting them in a Context.
+```js
+function User(props) {
+  <UserContext.Provider value={props.data}>
+    {/* my component content  */}
+  </UserContext.Provider>
+}
+
+// Somewhere else
+function UserDetails() {
+  const user = useContext(UserContext)
+  // render stuff
+}
+```
+
+## SPAs in Deployed Environments
+
+When deploying applications that use a client-side router that does not rely on Server Side Rendering you need to handle redirects to your index page so that loading from other URLs does not cause your CDN or Hosting to return not found for pages that aren't actually there.
+
+Each provider has a different way of doing this. For example, on Netlify you create a `_redirects` file that contains:
+
+```sh
+/*   /index.html   200
+```
+
+On Vercel you add a rewrites section to your `vercel.json`:
+
+```json
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}
+```
+
+---
+---
+---
 
 <Callout>
 	Access to more comprehensive insights and details on Solid Router can be


### PR DESCRIPTION
Addresses #507 

This is a quick version.   It is fully updated for solid-router v0.10.x. It is based mostly on the solid-router README.  I hope to have time in the next couple of weeks to add more detail, especially on `createAsync` as mentioned by @atilafassina.

I have reordered the initial sections in the form of a Quick Start so that users looking to get up and running fast have the most relevant information to doing so. To communicate the idea that it is a process to follow I used numbering differently than other doc in this repo. If you don't like the way I did it I am very happy to take the bold off of the numbered lines so that they will be indented as in other pages of the doc.

Beyond the Quick Start section, this doc is derived directly from the router README, to which I only made spelling, punctuation and grammar corrections.




