### PR TITLE
non-tracking `setCount`

### DIFF
--- a/src/routes/advanced-concepts/fine-grained-reactivity.mdx
+++ b/src/routes/advanced-concepts/fine-grained-reactivity.mdx
@@ -206,7 +206,7 @@ createEffect(() => {
 });
 
 setInterval(() => {
-	setCount(count() + 1);
+	setCount((prev) => prev + 1);
 }, 1000);
 ```
 

--- a/src/routes/concepts/components/basics.mdx
+++ b/src/routes/concepts/components/basics.mdx
@@ -10,7 +10,7 @@ Components are functions that return [JSX](/concepts/understanding-jsx) elements
 
 ```tsx
 function MyComponent() {
-	return <div>Hello World</div>
+	return <div>Hello World</div>;
 }
 ```
 
@@ -23,7 +23,7 @@ function App() {
 		<div>
 			<MyComponent />
 		</div>
-	)
+	);
 }
 ```
 
@@ -93,18 +93,16 @@ This allows for components to be reused in different contexts without affecting 
 
 ```tsx
 function MyComponent() {
-	const [count, setCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
 
-	console.log(count())
+	console.log(count());
 
 	return (
 		<div>
 			<p>Count: {count()}</p>
-			<button onClick={() => setCount(count() + 1)}>
-				Increment
-			</button>
+			<button onClick={() => setCount((prev) => prev + 1)}>Increment</button>
 		</div>
-	)
+	);
 }
 ```
 
@@ -128,7 +126,7 @@ This design ensures that conditional paths are clear and immediately understood.
 
 ```tsx
 function MyComponent() {
-	const [count, setCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
 	return (
 		<div>
 			{count() > 5 ? (
@@ -136,11 +134,13 @@ function MyComponent() {
 			) : (
 				<>
 					<p>Count: {count()}</p>
-					<button onClick={() => setCount(count() + 1)}>Increment</button>
+					<button onClick={() => setCount((prev) => prev + 1)}>
+						Increment
+					</button>
 				</>
 			)}
 		</div>
-	)
+	);
 }
 ```
 
@@ -162,7 +162,7 @@ To simplify conditional rendering, Solid provides built-in [control-flow](/conce
     				fallback={
     					<>
     						<p>Count: {count()}</p>
-    						<button onClick={() => setCount(count() + 1)}>Increment</button>
+    						<button onClick={() => setCount((prev) => prev+1)}>Increment</button>
     					</>
     				}
     			>
@@ -172,6 +172,7 @@ To simplify conditional rendering, Solid provides built-in [control-flow](/conce
     	)
     }
     ```
+
 </Callout>
 
 ## Importing and exporting
@@ -226,14 +227,14 @@ When importing a named export, you must specify the name of the component to imp
 
 ```tsx
 // App.ts
-import { MyComponent } from "./MyComponent"
+import { MyComponent } from "./MyComponent";
 
 function App() {
 	return (
 		<div>
 			<MyComponent />
 		</div>
-	)
+	);
 }
 ```
 
@@ -242,7 +243,7 @@ Additionally, it allows for multiple components to be imported from the same fil
 
 ```tsx
 // App.ts
-import { MyComponent, MyOtherComponent } from "./MyComponent"
+import { MyComponent, MyOtherComponent } from "./MyComponent";
 
 function App() {
 	return (
@@ -250,7 +251,7 @@ function App() {
 			<MyComponent />
 			<MyOtherComponent />
 		</div>
-	)
+	);
 }
 ```
 
@@ -260,14 +261,14 @@ To import a default export, you must specify the name of the component to import
 
 ```tsx
 // App.ts
-import MyComponent from "./MyComponent"
+import MyComponent from "./MyComponent";
 
 function App() {
 	return (
 		<div>
 			<MyComponent />
 		</div>
-	)
+	);
 }
 ```
 
@@ -277,13 +278,13 @@ To use Solid, you must import the Solid library.
 The reactive primitives and utilities are exported from Solid's main module.
 
 ```tsx
-import { createSignal } from "solid-js"
+import { createSignal } from "solid-js";
 ```
 
 However, some of Solid's utilities are exported from their own modules.
 
 ```tsx
-import { createStore } from "solid-js/store"
+import { createStore } from "solid-js/store";
 ```
 
 To see a full list of Solid's utilities, the Reference Tab in the sidebar provides the API Documentation.

--- a/src/routes/concepts/context.mdx
+++ b/src/routes/concepts/context.mdx
@@ -25,15 +25,11 @@ This function has a `Provider` property that wraps the component tree you want t
 ```jsx
 import { createContext } from "solid-js";
 
-const MyContext = createContext()
+const MyContext = createContext();
 
 export const Provider = (props) => {
-	return (
-		<MyContext.Provider>
-			{props.children}
-		</MyContext.Provider>
-	)
-}
+	return <MyContext.Provider>{props.children}</MyContext.Provider>;
+};
 ```
 
 ## Providing context to children
@@ -44,84 +40,30 @@ Once a value is passed to the `Provider`, it is available to all components that
 When passing a single value, it can be directly passed to the `value` prop:
 
 ```jsx
-import { createContext, useContext } from "solid-js"
+import { createContext, useContext } from "solid-js";
 
-const MyContext = createContext("initial")
+const MyContext = createContext("initial");
 
 const Provider = (props) => (
 	<MyContext.Provider value="new value">{props.children}</MyContext.Provider>
-)
+);
 ```
 
 However, if you need to access multiple values, they must be passed as an object literal, or using double curly braces (`{{ }}`):
 
 ```jsx
-import { createContext, createSignal } from "solid-js"
+import { createContext, createSignal } from "solid-js";
 
-const MyContext = createContext("default value")
+const MyContext = createContext("default value");
 
 export const Provider = (props) => {
-	const stringVal = "new value"
+	const stringVal = "new value";
 	const numberVal = 3;
 	const objVal = {
 		foo: "bar",
 		obj: true,
-		};
+	};
 
-	return (
-		<MyContext.Provider value={{
-			stringVal,
-			numberVal,
-			objVal
-		}}>
-			{props.children}
-		</MyContext.Provider>
-	)
-}
-```
-
-## Consuming context
-
-Once the values are available to all the components in the context's component tree, they can be accessed using the [`useContext`](/reference/component-apis/use-context) utility.
-This utility takes in the context object and returns the value(s) passed to the `Provider`:
-
-```jsx
-import { createContext, useContext } from "solid-js"
-
-const MyContext = createContext()
-
-const Provider = (props) => (
-	<MyContext.Provider value="new value">{props.children}</MyContext.Provider>
-)
-
-const Child = () => {
-	const value = useContext(MyContext)
-	return <>{value}</>
-}
-
-export const App = () => (
-	<Provider>
-		<Child /> {/* "new value" */}
-	</Provider>
-)
-```
-
-When you are passing multiple values into the `Provider`, you can destructure the context object to access the values you need.
-This provides a readable way to access the values you need without having to access the entire context object:
-
-```jsx
-import { createContext, useContext, createSignal } from "solid-js"
-
-const MyContext = createContext()
-
-const Provider = (props) => {
-	const stringVal = "new value"
-	const numberVal = 3
-	const objVal = {
-		foo: "bar",
-		obj: true,
-	}
-	const [signal, setSignal] = createSignal("example signal")
 	return (
 		<MyContext.Provider
 			value={{
@@ -132,24 +74,80 @@ const Provider = (props) => {
 		>
 			{props.children}
 		</MyContext.Provider>
-	)
-}
+	);
+};
+```
+
+## Consuming context
+
+Once the values are available to all the components in the context's component tree, they can be accessed using the [`useContext`](/reference/component-apis/use-context) utility.
+This utility takes in the context object and returns the value(s) passed to the `Provider`:
+
+```jsx
+import { createContext, useContext } from "solid-js";
+
+const MyContext = createContext();
+
+const Provider = (props) => (
+	<MyContext.Provider value="new value">{props.children}</MyContext.Provider>
+);
 
 const Child = () => {
-	const { stringVal, numberVal } = useContext(MyContext) // only access the values you need through destructuring
+	const value = useContext(MyContext);
+	return <>{value}</>;
+};
+
+export const App = () => (
+	<Provider>
+		<Child /> {/* "new value" */}
+	</Provider>
+);
+```
+
+When you are passing multiple values into the `Provider`, you can destructure the context object to access the values you need.
+This provides a readable way to access the values you need without having to access the entire context object:
+
+```jsx
+import { createContext, useContext, createSignal } from "solid-js";
+
+const MyContext = createContext();
+
+const Provider = (props) => {
+	const stringVal = "new value";
+	const numberVal = 3;
+	const objVal = {
+		foo: "bar",
+		obj: true,
+	};
+	const [signal, setSignal] = createSignal("example signal");
+	return (
+		<MyContext.Provider
+			value={{
+				stringVal,
+				numberVal,
+				objVal,
+			}}
+		>
+			{props.children}
+		</MyContext.Provider>
+	);
+};
+
+const Child = () => {
+	const { stringVal, numberVal } = useContext(MyContext); // only access the values you need through destructuring
 	return (
 		<>
 			<h1>{stringVal}</h1>
 			<span>{numberVal}</span>
 		</>
-	)
-}
+	);
+};
 
 export const App = () => (
 	<Provider>
 		<Child />
 	</Provider>
-)
+);
 ```
 
 ## Customizing context utilities
@@ -161,25 +159,25 @@ For example, when wrapping a component tree, you may want to create a custom `Pr
 This also provides you with the option of re-using the `Provider` component in other parts of your application, if needed.
 
 ```jsx
-import { createSignal, createContext, useContext } from "solid-js"
+import { createSignal, createContext, useContext } from "solid-js";
 
-const CounterContext = createContext()
+const CounterContext = createContext();
 
 export function CounterProvider(props) {
-	let count = 0
+	let count = 0;
 
 	return (
 		<CounterContext.Provider value={count}>
 			{props.children}
 		</CounterContext.Provider>
-	)
+	);
 }
 ```
 
 Now if you had to access the Provider in different areas of your application, you can simply import the `CounterProvider` component and wrap the component tree:
 
 ```jsx
-import { CounterProvider } from "./counterProvider"
+import { CounterProvider } from "./counterProvider";
 
 export function App() {
 	return (
@@ -187,7 +185,7 @@ export function App() {
 			<h1>Welcome to Counter</h1>
 			<NestedComponents />
 		</CounterProvider>
-	)
+	);
 }
 ```
 
@@ -196,22 +194,22 @@ Instead of importing `useContext` and passing in the context object on each comp
 
 ```jsx
 export function useCounter() {
-	return useContext(CounterContext)
+	return useContext(CounterContext);
 }
 ```
 
 The `useCounter()` utility in this example can now be imported into any component that needs to access the context values:
 
 ```jsx
-import { useCounter } from "./counter"
+import { useCounter } from "./counter";
 
 export function CounterProvider(props) {
-	const count = useCounter()
+	const count = useCounter();
 	return (
 		<>
 			<div>{count()}</div>
 		</>
-	)
+	);
 }
 ```
 
@@ -220,11 +218,11 @@ export function CounterProvider(props) {
 [Signals](/concepts/signals) offer a way to synchronize and manage data shared across your components using context.
 You can pass a signal directly to the `value` prop of the `Provider` component, and any changes to the signal will be reflected in all components that consume the context.
 
-		<TabsCodeBlocks>
-					<div id="App.jsx">
-					```jsx
-		import Counter from "./counter";
-		import { CounterProvider } from "./counter";
+    	<TabsCodeBlocks>
+    				<div id="App.jsx">
+    				```jsx
+    	import Counter from "./counter";
+    	import { CounterProvider } from "./counter";
 
     	export function App() {
     		return (
@@ -248,10 +246,10 @@ You can pass a signal directly to the `value` prop of the `Provider` component, 
     		count,
     		{
     			increment() {
-    			setCount(c => c + 1);
+    			setCount(prev => prev + 1);
     			},
     			decrement() {
-    			setCount(c => c - 1);
+    			setCount(prev => prev - 1);
     			}
     		}
     		];
@@ -284,7 +282,7 @@ You can pass a signal directly to the `value` prop of the `Provider` component, 
     ```
     			</div>
 
-					</TabsCodeBlocks>
+    				</TabsCodeBlocks>
 
 This offers a way to manage state across your components without having to pass props through intermediate elements.
 

--- a/src/routes/concepts/effects.mdx
+++ b/src/routes/concepts/effects.mdx
@@ -12,13 +12,13 @@ An effect is created using the `createEffect` function.
 This function takes a callback as its argument that runs when the effect is triggered.
 
 ```jsx
-import { createEffect } from "solid-js"
+import { createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 
 createEffect(() => {
-	console.log(count())
-})
+	console.log(count());
+});
 ```
 
 In this example, an effect is created that logs the current value of `count` to the console.
@@ -37,12 +37,12 @@ After this run, the effect will only be triggered when any of its _dependencies_
 
 ```jsx
 createEffect(() => {
-	console.log("hello") // will run only once
-})
+	console.log("hello"); // will run only once
+});
 
 createEffect(() => {
-	console.log(count()) // will run every time count changes
-})
+	console.log(count()); // will run every time count changes
+});
 ```
 
 Solid automatically tracks the dependencies of an effect, so you do not need to manually specify them.
@@ -54,13 +54,13 @@ When an effect is set to observe a signal, it creates a subscription to it.
 This subscription allows the effect to track the changes in the signal's value, which causes it to observe any changes that may happen and to execute its callback accordingly.
 
 ```jsx
-import { createSignal, createEffect } from "solid-js"
+import { createSignal, createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 
 createEffect(() => {
-	console.log(count()) // Logs the current value of count whenever it changes
-})
+	console.log(count()); // Logs the current value of count whenever it changes
+});
 ```
 
 ### Managing multiple signals
@@ -74,17 +74,17 @@ The effect will run even if only one of the signals changes, not necessarily all
 This means that the effect will run with the latest values of all of the signals that it is observing.
 
 ```jsx
-import { createSignal, createEffect } from "solid-js"
+import { createSignal, createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0)
-const [message, setMessage] = createSignal("Hello")
+const [count, setCount] = createSignal(0);
+const [message, setMessage] = createSignal("Hello");
 
 createEffect(() => {
-	console.log(count(), message())
-})
+	console.log(count(), message());
+});
 
-setCount(1) // Output: 1, "Hello"
-setMessage("World") // Output: 1, "World"
+setCount(1); // Output: 1, "Hello"
+setMessage("World"); // Output: 1, "World"
 ```
 
     	<Callout>
@@ -101,10 +101,10 @@ This allows each effect to independently track its own dependencies, without aff
 
 ```jsx
 createEffect(() => {
-	console.log("Outer effect starts")
-	createEffect(() => console.log("Inner effect"))
-	console.log("Outer effect ends")
-})
+	console.log("Outer effect starts");
+	createEffect(() => console.log("Inner effect"));
+	console.log("Outer effect ends");
+});
 ```
 
 The order of execution is important to note.
@@ -113,15 +113,15 @@ Signals that are accessed within an inner effect, will _not_ be registered as de
 When the signal located within the inner effect changes, it will trigger only the _inner effect_ to re-run, not the outer one.
 
 ```jsx
-import { createSignal, createEffect } from "solid-js"
+import { createSignal, createEffect } from "solid-js";
 
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 
 createEffect(() => {
-	console.log("Outer effect starts")
-	createEffect(() => console.log(count())) // when count changes, only the this effect will run
-	console.log("Outer effect ends")
-})
+	console.log("Outer effect starts");
+	createEffect(() => console.log(count())); // when count changes, only the this effect will run
+	console.log("Outer effect ends");
+});
 ```
 
 This forces each effect to be independent of each other, which helps to avoid unexpected behaviour.
@@ -140,22 +140,22 @@ This lifecycle function is similar to an effect, but it does not track any depen
 Rather, once the component has been intialized, the `onMount` callback will be executed and will not run again.
 
 ```jsx
-import { onMount } from "solid-js"
+import { onMount } from "solid-js";
 
 function Component() {
-	const [data, setData] = createSignal(null)
+	const [data, setData] = createSignal(null);
 
 	createEffect(() => {
-		data() // will run every time data changes
-	})
+		data(); // will run every time data changes
+	});
 
 	onMount(async () => {
 		// will run only once, when the component is mounted
-		const fetchedData = await fetch("https://example.com/data")
-		setData(fetchedData)
-	})
+		const fetchedData = await fetch("https://example.com/data");
+		setData(fetchedData);
+	});
 
-	return <div>...</div>
+	return <div>...</div>;
 }
 ```
 
@@ -169,20 +169,20 @@ While `onMount` is useful for running a side effect once, [`onCleanup`](/referen
 `onCleanup` will run whenever the component unmounts, removing any subscriptions that the effect has.
 
 ```jsx
-import { onCleanup } from "solid-js"
+import { onCleanup } from "solid-js";
 
 function App() {
-	const [count, setCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
 
 	const timer = setInterval(() => {
-		setCount(count() + 1)
-	}, 1000)
+		setCount((prev) => prev + 1);
+	}, 1000);
 
 	onCleanup(() => {
-		clearInterval(timer)
-	})
+		clearInterval(timer);
+	});
 
-	return <div>Count: {count()}</div>
+	return <div>Count: {count()}</div>;
 }
 ```
 

--- a/src/routes/concepts/intro-to-reactivity.mdx
+++ b/src/routes/concepts/intro-to-reactivity.mdx
@@ -17,8 +17,8 @@ With Solid, reactivity is the basis of its design, ensuring application's stay u
 
 ```jsx
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const increment = () => setCount(count() + 1)
+	const [count, setCount] = createSignal(0);
+	const increment = () => setCount((prev) => prev + 1);
 
 	return (
 		<div>
@@ -28,7 +28,7 @@ function Counter() {
 				Increment
 			</button>
 		</div>
-	)
+	);
 }
 ```
 
@@ -49,7 +49,7 @@ They are responsible for storing and managing data, as well as triggering update
 This is done through the use of getters and setters.
 
 ```jsx
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 //     ^ getter  ^ setter
 ```
 
@@ -66,11 +66,11 @@ const [count, setCount] = createSignal(0)
   To trigger reactive updates across an application, you call a setter to update the value of a signal.
 
 ```js
-console.log(count()) // `count()` is a getter that returns the current value of `count`, which is `0`.
+console.log(count()); // `count()` is a getter that returns the current value of `count`, which is `0`.
 
-setCount(1) // the setter, `setCount`, updates the value of `count`.
+setCount(1); // the setter, `setCount`, updates the value of `count`.
 
-console.log(count()) // the updated value of `count` is now `1`.
+console.log(count()); // the updated value of `count` is now `1`.
 ```
 
 ### Subscribers
@@ -89,12 +89,12 @@ Subscribers work based on two main actions:
 
 ```jsx
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const increment = () => setCount(count() + 1)
+	const [count, setCount] = createSignal(0);
+	const increment = () => setCount((prev) => prev + 1);
 
 	createEffect(() => {
-		console.log(count())
-	})
+		console.log(count());
+	});
 	// the `createEffect` will trigger the console log every time `count` changes.
 }
 ```
@@ -116,11 +116,11 @@ When a signal is not accessed within a tracking scope, an update to the signal w
 This happens because if a signal is not being tracked, it is not able to notify any subscribers of the change.
 
 ```jsx
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 
-console.log("Count:", count())
+console.log("Count:", count());
 
-setCount(1)
+setCount(1);
 
 // Output: Count: 0
 
@@ -132,13 +132,13 @@ To track a signal, it must be accessed within the scope of a subscriber.
 Reactive primitives, such as [effects](/concepts/effects), can be used to create subscribers.
 
 ```jsx
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 
 createEffect(() => {
-	console.log("Count:", count())
-})
+	console.log("Count:", count());
+});
 
-setCount(1)
+setCount(1);
 
 // Output: Count: 0
 //         Count: 1
@@ -151,8 +151,8 @@ JSX creates a tracking scope behind the scenes, which allows signals to be track
 
 ```jsx
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const increment = () => setCount(count() + 1)
+	const [count, setCount] = createSignal(0);
+	const increment = () => setCount((prev) => prev + 1);
 
 	return (
 		<div>
@@ -162,7 +162,7 @@ function Counter() {
 				Increment
 			</button>
 		</div>
-	)
+	);
 }
 ```
 
@@ -171,14 +171,14 @@ This means that if a signal is accessed outside of the return statement, will ru
 
 ```jsx
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const increment = () => setCount(count() + 1)
+	const [count, setCount] = createSignal(0);
+	const increment = () => setCount((prev) => prev + 1);
 
-	console.log("Count:", count()) // ❌ not tracked - only runs once during initialization.
+	console.log("Count:", count()); // ❌ not tracked - only runs once during initialization.
 
 	createEffect(() => {
-		console.log(count()) // ✅ will update whenever `count()` changes.
-	})
+		console.log(count()); // ✅ will update whenever `count()` changes.
+	});
 
 	return (
 		<div>
@@ -188,7 +188,7 @@ function Counter() {
 				Increment
 			</button>
 		</div>
-	)
+	);
 }
 ```
 
@@ -210,12 +210,12 @@ This is useful in scenarios where the order of updates is important.
 For example, if a subscriber depends on another signal, it is important that the subscriber is updated after the signal it depends on.
 
 ```jsx
-const [count, setCount] = createSignal(0)
-const [double, setDouble] = createSignal(0)
+const [count, setCount] = createSignal(0);
+const [double, setDouble] = createSignal(0);
 
 createEffect(() => {
-	setDouble(count() * 2)
-})
+	setDouble(count() * 2);
+});
 // The `double` signal will always be updated after `count` due to synchronous reactivity.
 // This ensures that `double` is always up-to-date with the latest value of `count`.
 ```

--- a/src/routes/concepts/signals.mdx
+++ b/src/routes/concepts/signals.mdx
@@ -58,7 +58,7 @@ Once a signal's value changes, it notifies all of its dependencies of the change
 ```jsx
 function Counter() {
 	const [count, setCount] = createSignal(0);
-	const increment = () => setCount(count() + 1);
+	const increment = () => setCount((prev) => prev + 1);
 
 	return (
 		<div>

--- a/src/routes/configuration/typescript.mdx
+++ b/src/routes/configuration/typescript.mdx
@@ -97,7 +97,7 @@ export default MyTsComponent
 If using an existing JavaScript component, import the TypeScript component:
 
 ```jsx
-import MyTsComponent from "./MyTsComponent"
+import MyTsComponent from "./MyTsComponent";
 
 function MyJsComponent() {
 	return (
@@ -105,7 +105,7 @@ function MyJsComponent() {
 			{/* ... */}
 			<MyTsComponent />
 		</>
-	)
+	);
 }
 ```
 
@@ -113,7 +113,7 @@ function MyJsComponent() {
 If you wish to change the entry point file from `index.jsx` to `index.tsx`, you need to modify the `src` attribute in `<script>` to look like the following:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<!-- ... -->
@@ -140,15 +140,15 @@ In addition, there are several helpful definitions to make it easier for specify
 Using `createSignal<T>`, a signal's type can be defined as `T`.
 
 ```ts
-const [count, setCount] = createSignal<number>()
+const [count, setCount] = createSignal<number>();
 ```
 
 Here, `createSignal` has the return type `Signal<number | undefined>`, which corresponds to the type passed into it, and `undefined` as it was uninitialized.
 This resolves to a getter-setter [tuple](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types), both of which are generically typed:
 
 ```typescript
-import type { Signal, Accessor, Setter } from "solid-js"
-type Signal<T> = [get: Accessor<T>, set: Setter<T>]
+import type { Signal, Accessor, Setter } from "solid-js";
+type Signal<T> = [get: Accessor<T>, set: Setter<T>];
 ```
 
 In Solid, a signal's getter, like `count`, is essentially a function that returns a specific type.
@@ -173,7 +173,7 @@ This is because it can not distinguish whether the function should be executed t
 In these situations, using the callback form of the setter is recommended:
 
 ```ts
-setSignal(() => value)
+setSignal(() => value);
 ```
 
 #### Default values
@@ -182,8 +182,8 @@ By providing default values when `createSignal` is called, the need for explicit
 This leverages type inference to determine the type automatically:
 
 ```typescript
-const [count, setCount] = createSignal(0)
-const [name, setName] = createSignal("")
+const [count, setCount] = createSignal(0);
+const [name, setName] = createSignal("");
 ```
 
 In this example, TypeScript understands the types as `number` and `string`.
@@ -194,7 +194,7 @@ This means that `count` and `name` directly receive the types `Accessor<number>`
 Just as signals use `createSignal<T>`, context uses `createContext<T>`, which is parameterized by the type `T` of the context's value:
 
 ```tsx
-type Data = { count: number; name: string }
+type Data = { count: number; name: string };
 ```
 
 When invoking `useContext(dataContext)`, the type contained within the context is returned.
@@ -208,7 +208,7 @@ The `| undefined` arises when the context's value will be used but cannot be det
 Much like [default values](#default-values) in signals, `| undefined` can be avoided in the type by giving a default value that will be returned if no value is assigned by a context provider:
 
 ```typescript
-const dataContext = createContext({ count: 0, name: "" })
+const dataContext = createContext({ count: 0, name: "" });
 ```
 
 By providing a default value, TypeScript determines that `dataContext` is `Context<{ count: number, name: string }>`.
@@ -219,25 +219,25 @@ By using TypeScript's [`ReturnType`](https://www.typescriptlang.org/docs/handboo
 
 ```tsx
 export const makeCountNameContext = (initialCount = 0, initialName = "") => {
-	const [count, setCount] = createSignal(initialCount)
-	const [name, setName] = createSignal(initialName)
+	const [count, setCount] = createSignal(initialCount);
+	const [name, setName] = createSignal(initialName);
 	return [
 		{ count, name },
 		{ setCount, setName },
-	] as const
-}
+	] as const;
+};
 
-type CountNameContextType = ReturnType<typeof makeCountNameContext>
-export const CountNameContext = createContext<CountNameContextType>()
+type CountNameContextType = ReturnType<typeof makeCountNameContext>;
+export const CountNameContext = createContext<CountNameContextType>();
 ```
 
 `CountNameContextType` will correspond to the result of `makeCountNameContext`:
 
 ```tsx
-;[
+[
 	{ count: Accessor<number>, name: Accessor<string> },
 	{ setCount: Setter<number>, setName: Setter<string> },
-]
+];
 ```
 
 To retrieve the context, use `useCountNameContext`, which has a type signature of `() => CountNameContextType | undefined`.
@@ -247,14 +247,14 @@ Additionally, throwing a readable error may be preferable to non-null asserting:
 
 ```tsx
 export const useCountNameContext = () => {
-	const countName = useContext(CountNameContext)
+	const countName = useContext(CountNameContext);
 	if (!countName) {
 		throw new Error(
 			"useCountNameContext should be called inside its ContextProvider"
-		)
+		);
 	}
-	return countName
-}
+	return countName;
+};
 ```
 
 **Note:** While supplying a default value to `createContext` can make the context perpetually defined, this approach may not always be advisable.
@@ -281,14 +281,16 @@ Trying to pass unneccessary props or children will result in type errors:
 ```tsx
 // in counter.tsx
 const Counter: Component = () => {
-	const [count, setCount] = createSignal(0)
-	return <button onClick={() => setCount((c) => c + 1)}>{count()}</button>
-}
+	const [count, setCount] = createSignal(0);
+	return (
+		<button onClick={() => setCount((prev) => prev + 1)}>{count()}</button>
+	);
+};
 
 // in app.tsx
-;<Counter /> // ✔️
-;<Counter initial={5} /> // ❌: No 'initial' prop defined
-;<Counter>hi</Counter> // ❌: Children aren't expected
+<Counter />; // ✔️
+<Counter initial={5} />; // ❌: No 'initial' prop defined
+<Counter>hi</Counter>; // ❌: Children aren't expected
 ```
 
 #### Components with props
@@ -297,11 +299,13 @@ For components that require the use of props, they can be typed using [generics]
 
 ```tsx
 const InitCounter: Component<{ initial: number }> = (props) => {
-	const [count, setCount] = createSignal(props.initial)
-	return <button onClick={() => setCount((c) => c + 1)}>{count()}</button>
-}
+	const [count, setCount] = createSignal(props.initial);
+	return (
+		<button onClick={() => setCount((prev) => prev + 1)}>{count()}</button>
+	);
+};
 
-;<InitCounter initial={5} />
+<InitCounter initial={5} />;
 ```
 
 #### Components with children
@@ -311,17 +315,17 @@ For this, Solid provides `ParentComponent`, which includes `children?` as an opt
 If defining a component with the `function` keyword, `ParentProps` can be used as a helper for the props:
 
 ```tsx
-import { ParentComponent } from "solid-js"
+import { ParentComponent } from "solid-js";
 
 const CustomCounter: ParentComponent = (props) => {
-	const [count, setCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
 	return (
-		<button onClick={() => setCount((c) => c + 1)}>
+		<button onClick={() => setCount((prev) => prev + 1)}>
 			{count()}
 			{props.children}
 		</button>
-	)
-}
+	);
+};
 ```
 
 In this example, `props` is inferred to be of the type `{children?: JSX.Element }`, streamlining the process of defining components that can accept children.
@@ -360,7 +364,7 @@ const MyGenericComponent = <T extends unknown>(
 	props: MyProps<T>
 ): JSX.Element => {
 	/* ... */
-}
+};
 
 // Using a function declaration for a generic component
 function MyGenericComponent<T>(props: MyProps<T>): JSX.Element {
@@ -402,7 +406,7 @@ Defining an event handler inline within a JSX attribute automatically provides t
 ```tsx
 <input
 	onInput={(event) => {
-		console.log("Input changed to", event.currentTarget.value)
+		console.log("Input changed to", event.currentTarget.value);
 	}}
 />
 ```
@@ -425,12 +429,12 @@ For specific events like `Input` and `Focus` that are directly associated with i
 In an environment without TypeScript, using the `ref` attribute in Solid ensures that the corresponding DOM element is assigned to the variable after it is rendered:
 
 ```js
-let divRef
-console.log(divRef) // Outputs: undefined
+let divRef;
+console.log(divRef); // Outputs: undefined
 onMount(() => {
-	console.log(divRef) // Outputs: <div> element
-})
-return <div ref={divRef} />
+	console.log(divRef); // Outputs: <div> element
+});
+return <div ref={divRef} />;
 ```
 
 In a TypeScript environment, particularly with strict `null` checks enabled, typing these variables can be a challenge.
@@ -452,8 +456,8 @@ Within the scope of the `onMount` function, which runs after rendering, you can 
 
 ```typescript
 onMount(() => {
-	divRef!.focus()
-})
+	divRef!.focus();
+});
 ```
 
 Another approach is to bypass `null` during the assignment phase and then apply a definite assignment assertion within the `ref` attribute:
@@ -471,27 +475,27 @@ return <div ref={divRef!}>...</div>
 In this case, using `divRef!` within the `ref` attribute signals to TypeScript that `divRef` will receive an assignment after this stage, which is more in line with how Solid works.
 
 <Callout>
-	While TypeScript does catch incorrect usage of refs that occur
-	before their JSX block definition, it currently does not identify undefined
-	variables within certain nested functions in Solid. Therefore, additional care
-	is needed when using `ref`s in functions such as
+	While TypeScript does catch incorrect usage of refs that occur before their
+	JSX block definition, it currently does not identify undefined variables
+	within certain nested functions in Solid. Therefore, additional care is needed
+	when using `ref`s in functions such as
 	[`createMemo`](/reference/basic-reactivity/create-memo),
-	[`createRenderEffect`](/reference/secondary-primitives/create-render-effect), and
-	[`createComputed`](/reference/secondary-primitives/create-computed).
+	[`createRenderEffect`](/reference/secondary-primitives/create-render-effect),
+	and [`createComputed`](/reference/secondary-primitives/create-computed).
 </Callout>
 
 Finally, a riskier approach involves using the definite assignment assertion right at the point of variable initialization.
 While this method bypasses TypeScript's assignment checks for that particular variable, it offers a quick but less secure workaround that could lead to runtime errors.
 
 ```typescript
-let divRef!: HTMLDivElement
+let divRef!: HTMLDivElement;
 
 // Permitted by TypeScript but will throw an error at runtime:
 // divRef.focus();
 
 onMount(() => {
-	divRef.focus()
-})
+	divRef.focus();
+});
 ```
 
 ## Control flow-based narrowing
@@ -501,15 +505,15 @@ Control flow-based narrowing involves refining the type of a value by using cont
 Consider the following:
 
 ```tsx
-const user: User | undefined = maybeUser()
-return <div>{user && user.name}</div>
+const user: User | undefined = maybeUser();
+return <div>{user && user.name}</div>;
 ```
 
 In Solid, however, accessors cannot be narrowed in a similar way:
 
 ```tsx
-const [user, setUser] = createSignal<User>()
-return <div>{user() && user().name}</div>
+const [user, setUser] = createSignal<User>();
+return <div>{user() && user().name}</div>;
 //                    ^ Object may be 'undefined'.
 
 // Using `<Show>`:
@@ -520,13 +524,13 @@ return (
 			{user().name /* Object is possibly 'undefined' */}
 		</Show>
 	</div>
-)
+);
 ```
 
 In this case, using optional chaining serves as an good alternative:
 
 ```tsx
-return <div>{user()?.name}</div>
+return <div>{user()?.name}</div>;
 
 // Using `<Show>`:
 
@@ -534,7 +538,7 @@ return (
 	<div>
 		<Show when={user()}>{(nonNullishUser) => nonNullishUser().name}</Show>
 	</div>
-)
+);
 ```
 
 This approach is simillar using the keyed option, but offers an accessor to prevent the recreation of children each time the `when` value changes.
@@ -546,14 +550,14 @@ return (
 			{(nonNullishUser) => nonNullishUser.name}
 		</Show>
 	</div>
-)
+);
 ```
 
 Note that optional chaining may not always be possible.
 For instance, when a `UserPanel` component exclusively requires a `User` object:
 
 ```tsx
-return <UserPanel user={user()} />
+return <UserPanel user={user()} />;
 //                        ^ Type 'undefined' is not assignable to type 'User'.
 ```
 
@@ -567,13 +571,13 @@ return (
 	<Show when={user()}>
 		{(nonNullishUser) => <UserPanel user={nonNullishUser()} />}
 	</Show>
-)
+);
 ```
 
 Casting can also be a solution so long as the assumption is valid:
 
 ```tsx
-return <div>{user() && (user() as User).name}</div>
+return <div>{user() && (user() as User).name}</div>;
 ```
 
 It's worth noting that runtime type errors may arise from doing this.
@@ -583,12 +587,12 @@ This may happen when passing a type-cast value to a component, which discards in
 If the types in a union need to be differentiated, a memo or computed signal can work as an alternative solution:
 
 ```tsx
-type User = Admin | OtherUser
+type User = Admin | OtherUser;
 const admin = createMemo(() => {
-	const u = user()
-	return u && u.type === "admin" ? u : undefined
-})
-return <Show when={admin()}>{(a) => <AdminPanel user={a()} />}</Show>
+	const u = user();
+	return u && u.type === "admin" ? u : undefined;
+});
+return <Show when={admin()}>{(a) => <AdminPanel user={a()} />}</Show>;
 ```
 
 The following alternative also works when using `Show`:
@@ -596,8 +600,8 @@ The following alternative also works when using `Show`:
 ```tsx
 <Show
 	when={(() => {
-		const u = user()
-		return u && u.type === "admin" ? u : undefined
+		const u = user();
+		return u && u.type === "admin" ? u : undefined;
 	})()}
 >
 	{(admin) => <AdminPanel user={admin()} />}
@@ -613,27 +617,27 @@ Typing these events requires an extension of Solid's JSX namespace.
 
 ```tsx
 class NameEvent extends CustomEvent {
-	type: "Name"
-	detail: { name: string }
+	type: "Name";
+	detail: { name: string };
 
 	constructor(name: string) {
-		super("Name", { detail: { name } })
+		super("Name", { detail: { name } });
 	}
 }
 
 declare module "solid-js" {
 	namespace JSX {
 		interface CustomEvents {
-			Name: NameEvent // Matches `on:Name`
+			Name: NameEvent; // Matches `on:Name`
 		}
 		interface CustomCaptureEvents {
-			Name: NameEvent // Matches `oncapture:Name`
+			Name: NameEvent; // Matches `oncapture:Name`
 		}
 	}
 }
 
 // Usage
-;<div on:Name={(event) => console.log("name is", event.detail.name)} />
+<div on:Name={(event) => console.log("name is", event.detail.name)} />;
 ```
 
 <Callout>
@@ -708,43 +712,43 @@ function model(
 	element: Element, // directives can be used on any HTML and SVG element
 	value: Accessor<Signal<string>> // second param will always be an accessor in case value being reactive
 ) {
-	const [field, setField] = value()
-	createRenderEffect(() => (element.value = field()))
+	const [field, setField] = value();
+	createRenderEffect(() => (element.value = field()));
 	element.addEventListener("input", (e) => {
-		const value = (e.target as HTMLInputElement).value
-		setField(value)
-	})
+		const value = (e.target as HTMLInputElement).value;
+		setField(value);
+	});
 }
 
 declare module "solid-js" {
 	namespace JSX {
 		interface Directives {
-			model: Signal<string> // Corresponds to `use:model`
+			model: Signal<string>; // Corresponds to `use:model`
 		}
 	}
 }
 
 // Usage
-let [name, setName] = createSignal("")
-;<input type="text" use:model={[name, setName]} />
+let [name, setName] = createSignal("");
+<input type="text" use:model={[name, setName]} />;
 ```
 
 In using `DirectiveFunctions`, there's the ability to check both arguments (if present) by detailing the entire function type:
 
 ```tsx
 function model(element: HTMLInputElement, value: Accessor<Signal<string>>) {
-	const [field, setField] = value()
-	createRenderEffect(() => (element.value = field()))
-	element.addEventListener("input", (e) => setField(e.target.value))
+	const [field, setField] = value();
+	createRenderEffect(() => (element.value = field()));
+	element.addEventListener("input", (e) => setField(e.target.value));
 }
 
 function log(element: Element) {
-	console.log(element)
+	console.log(element);
 }
 
-let num = 0
+let num = 0;
 function count() {
-	num++
+	num++;
 }
 
 function foo(comp: Element, args: Accessor<string[]>) {
@@ -754,10 +758,10 @@ function foo(comp: Element, args: Accessor<string[]>) {
 declare module "solid-js" {
 	namespace JSX {
 		interface DirectiveFunctions {
-			model: typeof model
-			log: typeof log
-			count: typeof count
-			foo: typeof foo
+			model: typeof model;
+			log: typeof log;
+			count: typeof count;
+			foo: typeof foo;
 		}
 	}
 }

--- a/src/routes/guides/state-management.mdx
+++ b/src/routes/guides/state-management.mdx
@@ -3,7 +3,6 @@ title: State Management
 order: 2
 ---
 
-
 State management is process of handling and manipulating data that affects the behavior and presentation of a web application.
 To build interactive and dynamic web applications, state management is a critical aspect of development.
 Within Solid, state management is facilitated through the use of reactive primitives.
@@ -11,21 +10,21 @@ Within Solid, state management is facilitated through the use of reactive primit
 These state management concepts will be shown using a basic counter example:
 
 ```jsx
-import { createSignal } from "solid-js"
+import { createSignal } from "solid-js";
 
 function Counter() {
-	const [count, setCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
 
 	const increment = () => {
-		setCount(count() + 1)
-	}
+		setCount((prev) => prev + 1);
+	};
 
 	return (
 		<>
 			<div>Current count: {count()}</div>
 			<button onClick={increment}>Increment</button>
 		</>
-	)
+	);
 }
 ```
 
@@ -50,23 +49,23 @@ State is represented by a [signal](/concepts/signals), which is a reactive primi
 To create a piece of state, you use the [`createSignal`](/reference/basic-reactivity/create-signal) function and pass in the initial value of the state:
 
 ```jsx
-import { createSignal } from "solid-js"
+import { createSignal } from "solid-js";
 
-const [count, setCount] = createSignal(0)
+const [count, setCount] = createSignal(0);
 ```
 
 To access the current value of the state, you call the signal's getter function:
 
 ```jsx
-console.log(count()) // 0
+console.log(count()); // 0
 ```
 
 To update the state, you use the signal's setter function:
 
 ```jsx
-setCount(count() + 1)
+setCount((prev) => prev + 1);
 
-console.log(count()) // 1
+console.log(count()); // 1
 ```
 
 With signals, you can create and manage state in a simple and straightforward manner.
@@ -87,7 +86,7 @@ return (
 		<div>Current count: {count()}</div>
 		<button onClick={increment}>Increment</button>
 	</>
-)
+);
 ```
 
 To render the current state of `count`, the JSX expression `{count()}` is used.
@@ -111,19 +110,19 @@ For example, in the `Counter` component, you may want to display the doubled val
 This can be achieved through the use of [effects](/concepts/effects), which are reactive primitives that perform side effects when the state changes:
 
 ```jsx
-import { createSignal, createEffect } from "solid-js"
+import { createSignal, createEffect } from "solid-js";
 
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const [doubleCount, setDoubleCount] = createSignal(0) // Initialize a new state for doubleCount
+	const [count, setCount] = createSignal(0);
+	const [doubleCount, setDoubleCount] = createSignal(0); // Initialize a new state for doubleCount
 
 	const increment = () => {
-		setCount(count() + 1)
-	}
+		setCount((prev) => prev + 1);
+	};
 
 	createEffect(() => {
-		setDoubleCount(count() * 2) // Update doubleCount whenever count changes
-	})
+		setDoubleCount(count() * 2); // Update doubleCount whenever count changes
+	});
 
 	return (
 		<>
@@ -131,7 +130,7 @@ function Counter() {
 			<div>Doubled count: {doubleCount()}</div> // Display the doubled count
 			<button onClick={increment}>Increment</button>
 		</>
-	)
+	);
 }
 ```
 
@@ -155,24 +154,24 @@ This is a useful pattern when you want to display a transformation of a state va
 Derived values can be created through using a signal within a function, which can be referred to as a [derived signal](/concepts/derived-values/derived-signals):
 
 ```jsx
-import { createSignal } from "solid-js"
+import { createSignal } from "solid-js";
 
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const [doubleCount, setDoubleCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
+	const [doubleCount, setDoubleCount] = createSignal(0);
 
 	// Derived signal
 	const squaredCount = () => {
-		return count() * count()
-	}
+		return count() * count();
+	};
 
 	const increment = () => {
-		setCount(count() + 1)
-	}
+		setCount((prev) => prev + 1);
+	};
 
 	createEffect(() => {
-		setDoubleCount(count() * 2) // Update doubleCount whenever count changes
-	})
+		setDoubleCount(count() * 2); // Update doubleCount whenever count changes
+	});
 
 	return (
 		<>
@@ -180,7 +179,7 @@ function Counter() {
 			<div>Doubled count: {doubleCount()}</div>
 			<button onClick={increment}>Increment</button>
 		</>
-	)
+	);
 }
 ```
 
@@ -189,22 +188,22 @@ When a function is computationally expensive, or used multiple times within a co
 To avoid this, Solid introduced [Memos](/concepts/derived-values/memos):
 
 ```jsx
-import { createSignal, createEffect, createMemo } from "solid-js"
+import { createSignal, createEffect, createMemo } from "solid-js";
 
 function Counter() {
-	const [count, setCount] = createSignal(0)
-	const [doubleCount, setDoubleCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
+	const [doubleCount, setDoubleCount] = createSignal(0);
 
 	// Memo
-	const squaredCount = createMemo(() => count() * count())
+	const squaredCount = createMemo(() => count() * count());
 
 	const increment = () => {
-		setCount(count() + 1)
-	}
+		setCount((prev) => prev + 1);
+	};
 
 	const doubleCount = () => {
-		return count() * 2
-	}
+		return count() * 2;
+	};
 
 	return (
 		<>
@@ -215,7 +214,7 @@ function Counter() {
 				<div>Squared count: {squaredCount()}</div>
 			</div>
 		</>
-	)
+	);
 }
 ```
 
@@ -232,16 +231,16 @@ This can keep things synchronized across the [component tree](/concepts/componen
 For example, in the `Counter` component, you may want to display the doubled value of `count` to the user through a separate component:
 
 ```jsx
-import { createSignal, createEffect, createMemo } from "solid-js"
+import { createSignal, createEffect, createMemo } from "solid-js";
 
 function App() {
-	const [count, setCount] = createSignal(0)
-	const [doubleCount, setDoubleCount] = createSignal(0)
-	const squaredCount = createMemo(() => count() * count())
+	const [count, setCount] = createSignal(0);
+	const [doubleCount, setDoubleCount] = createSignal(0);
+	const squaredCount = createMemo(() => count() * count());
 
 	createEffect(() => {
-		setDoubleCount(count() * 2)
-	})
+		setDoubleCount(count() * 2);
+	});
 
 	return (
 		<>
@@ -252,15 +251,15 @@ function App() {
 				squaredCount={squaredCount()}
 			/>
 		</>
-	)
+	);
 }
 
 function Counter(props) {
 	const increment = () => {
-		props.setCount(props.count() + 1)
-	}
+		props.setCount((prev) => prev + 1);
+	};
 
-	return <button onClick={increment}>Increment</button>
+	return <button onClick={increment}>Increment</button>;
 }
 
 function DisplayCounts(props) {
@@ -270,10 +269,10 @@ function DisplayCounts(props) {
 			<div>Doubled count: {props.doubleCount}</div>
 			<div>Squared count: {props.squaredCount}</div>
 		</div>
-	)
+	);
 }
 
-export default App
+export default App;
 ```
 
 To share the `count` state between the `Counter` and `DisplayCounts` components, you can lift the state up to the `App` component.
@@ -287,6 +286,7 @@ However, you can pass down setter functions from the parent component to allow t
       To encourage one-way data flow, props are passed as read-only or immutable values from the parent to child components.
 
 There are [specific utlity functions for props](/concepts/components/props), however, that offer methods to modify props values.
+
 </Callout>
 
 ## Managing complex state

--- a/src/routes/reference/lifecycle/on-cleanup.mdx
+++ b/src/routes/reference/lifecycle/on-cleanup.mdx
@@ -7,26 +7,25 @@ order: 5
 Can be used in any Component or Effect to clean up any side effects that could be left behind when the component is removed from the page.
 
 ```ts
-function onCleanup(fn: () => void): void
-
+function onCleanup(fn: () => void): void;
 ```
 
 Without the `onCleanup` function, the event listener would remain attached to the document even after the component is removed from the page.
 This can cause memory leaks and other issues.
 
 ```tsx
-import { createSignal, onCleanup } from "solid-js"
+import { createSignal, onCleanup } from "solid-js";
 
 const Component = () => {
-	const [count, setCount] = createSignal(0)
+	const [count, setCount] = createSignal(0);
 
-	const handleClick = () => setCount(count() + 1)
+	const handleClick = () => setCount((prev) => prev + 1);
 
 	// Register a cleanup method to remove the event listener when the component is removed from the page.
 	onCleanup(() => {
-		document.removeEventListener("click", handleClick)
-	})
+		document.removeEventListener("click", handleClick);
+	});
 
-	return <button onClick={handleClick}>Clicked {count()} times</button>
-}
+	return <button onClick={handleClick}>Clicked {count()} times</button>;
+};
 ```

--- a/src/ui/layout/hero-code-snippet.tsx
+++ b/src/ui/layout/hero-code-snippet.tsx
@@ -6,8 +6,8 @@ export const counterTxt = `import { createSignal } from "solid-js";
 function Counter() {
 	const [count, setCount] = createSignal(0);
 
-	setInterval(() => setCount(count() + 1), 1000);
-	
+	setInterval(() => setCount((prev) => prev + 1), 1000);
+
 	return (
 		<div>
 			<p>Count: {count()}</p>
@@ -23,8 +23,8 @@ const renderCode = async () => {
 function Counter() {
 	const [count, setCount] = createSignal(0);
 
-	setInterval(() => setCount(count() + 1), 1000);
-	
+	setInterval(() => setCount((prev) => prev + 1), 1000);
+
 	return (
 		<div>
 			<p>Count: {count()}</p>


### PR DESCRIPTION
The pattern of `setCount(count()+1)` is unharmful most of the time but a bad practice because `count()` will cause tracking.  `setCount(prev => prev + 1)` is better, as it updates the signal without causing tracking.