### PR TITLE
Solid Start Reference section - initial move

### DIFF
--- a/scripts/collections/index.mjs
+++ b/scripts/collections/index.mjs
@@ -6,7 +6,7 @@ import { createI18nEntries } from "../create-i18n-entries.mjs";
 import { createI18nTree } from "../create-i18n-tree.mjs";
 
 export const languages = ["pt-br"];
-const projects = ["solid-router"];
+const projects = ["solid-router", "solid-start"];
 export const COLLECTIONS_ROOT = "src/routes";
 
 (async () => {

--- a/src/routes/solid-start/data.json
+++ b/src/routes/solid-start/data.json
@@ -1,0 +1,6 @@
+{
+	"title": "root",
+	"pages": [
+		
+	]
+}

--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Overview
+mainNavExclude: true
+---
+
+# SolidStart

--- a/src/routes/solid-start/reference/data.json
+++ b/src/routes/solid-start/reference/data.json
@@ -1,0 +1,4 @@
+{
+	"title": "Reference",
+	"pages": ["router", "server", "document", "entrypoints"]
+}

--- a/src/routes/solid-start/reference/document/HttpHeader.mdx
+++ b/src/routes/solid-start/reference/document/HttpHeader.mdx
@@ -1,0 +1,57 @@
+---
+title: HttpHeader
+---
+
+`HttpHeader` is a component that allows you set a header on the HTTP response sent by the server.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { HttpHeader } from "@solidjs/start";
+// ---cut---
+<HttpHeader name="x-robots-tag" value="noindex" />;
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Setting a header for catch-all routes
+
+```tsx twoslash filename="routes/*404.tsx"
+import { HttpHeader, HttpStatusCode } from "@solidjs/start";
+
+export default function NotFound() {
+  return (
+    <div>
+      <HttpStatusCode code={404} />
+      <HttpHeader name="my-header" value="header-value" />
+    </div>
+  );
+}
+```
+
+As you render the page you may want to add additional HTTP headers to the response. The `HttpHeader` component will do that for you. You can pass it a `name` and `value` and that will get added to the `Response` headers sent back to the browser.
+
+Keep in mind, when streaming responses(`renderStream`), HTTP headers can only be included that are added before the stream first flushed. Be sure to add `deferStream` to any resources that needed to be loaded before responding.
+
+## Reference
+
+### `<HttpHeader />`
+
+Import from `"@solidjs/start"` and use it anywhere in your component tree. It will add the header if that part of the tree is rendered on the server.
+
+```tsx twoslash
+import { HttpHeader } from "@solidjs/start";
+
+function Component() {
+  return <HttpHeader name="my-header" value="header-value" />;
+}
+```
+
+#### Props
+
+- `name` - The name of the header to set
+- `value` - The value of the header to set

--- a/src/routes/solid-start/reference/document/HttpStatusCode.mdx
+++ b/src/routes/solid-start/reference/document/HttpStatusCode.mdx
@@ -1,0 +1,76 @@
+---
+title: HttpStatusCode
+---
+
+`HttpStatusCode` is a component that sets the HTTP status code for the page response while server-side rendering.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { HttpStatusCode } from "@solidjs/start";
+// ---cut---
+<HttpStatusCode code={404} />;
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Setting a 404 status code for the unmatched routes
+
+As you render the page you may want to set the status code to the `Response` depending on how it goes. The `HttpStatusCode` component will do that for you. You can pass `code` and that will be set as the `Response` status sent back to the browser.
+
+Since `HttpStatusCode` is just a component, it can be used with `ErrorBoundaries`, `Show`, `Switch` or any of the other JSX control-flow components. So the same logic you are using to decide what to render should inform what status code you are setting. This allows that logic to sit together.
+
+Status codes are important tools for things like caching and SEO, so it's a good practice to send meaningful status codes. For example, for a `NotFound` page, you should send a `404` status code.
+
+```tsx twoslash {6} filename="routes/*404.tsx"
+import { HttpStatusCode } from "@solidjs/start";
+
+export default function NotFound() {
+  return (
+    <div>
+      <HttpStatusCode code={404} />
+      <h1>Page not found</h1>
+    </div>
+  );
+}
+```
+
+### Setting a 404 status code for missing pages for dynamic routes
+
+When you use dynamic params in routes, you may want to set a 404 status code if the given parameter for a segment points to a missing resource. Usually, you will find out that the param is missing when you do some async request with that param. You are probably inside a resource fetcher.
+
+You can throw errors from inside these fetchers. These will be caught by the nearest `<ErrorBoundary>` component from where the data is accessed. `<HttpStatusCode>` pairs very well with error boundaries. You can inspect the error in the ErrorBoundary's fallback. If the fetcher throws an error indicating the data was not found, render a `<HttpStatusCode code={404} />`.
+
+Keep in mind, when streaming responses (`renderStream`), the HTTP Status can only be included if added before the stream first flushed. Be sure to add `deferStream` to any resources calls that need to be loaded before responding.
+
+```tsx twoslash {7,17-19, 15, 23} filename="routes/[house].tsx"
+import { Show, ErrorBoundary } from "solid-js";
+import { cache, createAsync } from "@solidjs/router";
+import { HttpStatusCode } from "@solidjs/start";
+
+const getHouse = cache(async (house: string) => {
+  if (house != "gryffindor") {
+    throw new Error("House not found");
+  }
+  return house;
+}, "house");
+
+export default function House(props: { name: string }) {
+  const house = createAsync(() => getHouse(props.name), { deferStream: true });
+  return (
+    <ErrorBoundary
+      fallback={e => (
+        <Show when={e.message === "House not found"}>
+          <HttpStatusCode code={404} />
+        </Show>
+      )}
+    >
+      <div>{house()}</div>
+    </ErrorBoundary>
+  );
+}
+```

--- a/src/routes/solid-start/reference/document/data.json
+++ b/src/routes/solid-start/reference/document/data.json
@@ -1,0 +1,4 @@
+{
+	"title": "Document",
+	"pages": ["HttpHeader.mdx", "HttpStatusCode.mdx"]
+}

--- a/src/routes/solid-start/reference/entrypoints/app-config.mdx
+++ b/src/routes/solid-start/reference/entrypoints/app-config.mdx
@@ -1,0 +1,119 @@
+---
+title: app.config.ts
+---
+
+`app.config.ts` is where you configure your application.
+
+<div class="text-lg">
+
+```tsx
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  vite: {
+    // vite options
+    plugins: []
+  },
+  server: {
+    preset: "netlify"
+  }
+});
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Configuring your application
+
+SolidStart is built on top of [Vinxi](https://vinxi.vercel.app/) which combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io).
+
+The core configuration used by SolidStart is found at `@solidjs/start/config`.
+
+SolidStart supports most vite options, including plugins via the `vite` option:
+
+```tsx
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  vite: {
+    // vite options
+    plugins: []
+  }
+});
+```
+
+The `vite` option can also be a function which can be customized for each Vinxi router. In SolidStart we use 3, `server` for SSR, `client` for the browser, and `server-function` for server functions.
+
+```tsx
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  vite({ router }) {
+    if (router === "server") {
+    } else if (router === "client") {
+    } else if (router === "server-function") {
+    }
+    return { plugins: [] };
+  }
+});
+```
+
+SolidStart uses Nitro which can run on a number of platforms. The `server` option exposes some Nitro options including deployment presets.
+
+- Node
+- Static hosting
+- Netlify Functions & Edge
+- Vercel Functions & Edge
+- AWS Lambda & Lambda@Edge
+- Cloudflare Workers & Pages
+- Deno Deploy
+
+The simplest usage is passing no arguments, which defaults to the Node preset. Some presets may be autodetected by the provider. Otherwise they must added to the configuration via the `server.preset` option. For example, this uses Netlify Edge:
+
+```tsx
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  server: {
+    preset: "netlify_edge"
+  }
+});
+```
+
+#### Special Note
+
+SolidStart uses Async Local Storage. Not all non-node platforms support it out of the box. Netlify, Vercel, and Deno should just work. But for Cloudflare you will need specific config:
+
+```js
+import { defineConfig } from "@solidjs/start/config";
+
+export default defineConfig({
+  server: {
+    preset: "cloudflare_module",
+    rollupConfig: {
+      external: ["__STATIC_CONTENT_MANIFEST", "node:async_hooks"]
+    }
+  }
+});
+```
+
+And enable node compat in your wrangler.toml.
+
+```
+compatibility_flags = [ "nodejs_compat" ]
+```
+
+## Reference
+
+### `@solidjs/start/config`
+
+The vite options are same as the default with exception of the `start` property exposes the following options:
+
+- `server` (_object_): Nitro server config options
+- `appRoot` (_string_, default `"./src"`): Sets the root of the application code.
+- `routesDir` (_string_, default `"./routes"`): The path to where the routes are located.
+- `ssr` (_boolean_ | "sync" | "async", default `true`): Providing a boolean value will toggle between client rendering and [streaming](https://docs.solidjs.com/references/concepts/ssr/streaming) server rendering (ssr) mode, while "sync" and "async" will render using Solid's [renderToString](https://docs.solidjs.com/references/concepts/ssr/simple-client-fetching-ssr) and [renderToStringAsync](https://docs.solidjs.com/references/concepts/ssr/async-ssr) respectively.
+- `experimental.islands` (_boolean_, default `false`): _experimental_ toggles on "islands" mode.

--- a/src/routes/solid-start/reference/entrypoints/app.mdx
+++ b/src/routes/solid-start/reference/entrypoints/app.mdx
@@ -1,0 +1,43 @@
+---
+title: app.tsx
+---
+
+`app.tsx` defines the document that your application renders.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { MetaProvider, Title } from "@solidjs/meta";
+import { Router } from "@solidjs/router";
+import { FileRoutes } from "@solidjs/start/router";
+import { Suspense } from "solid-js";
+
+export default function App() {
+  return (
+    <Router
+      root={props => (
+        <MetaProvider>
+          <Title>SolidStart - Basic</Title>
+          <a href="/">Index</a>
+          <a href="/about">About</a>
+          <Suspense>{props.children}</Suspense>
+        </MetaProvider>
+      )}
+    >
+      <FileRoutes />
+    </Router>
+  );
+}
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Setting up your application
+
+The `App` component exported from `app.tsx` is the isomorphic (shared on server and browser) entry into your application. This is the point where the code runs on both sides. This is like the classic entry point you would find in Create React App or similar, where you can define your router, and other top level components.
+
+Our basic example (as shown above) includes `@solidjs/router` and `@solidjs/meta`. But this can really be whatever you want.

--- a/src/routes/solid-start/reference/entrypoints/data.json
+++ b/src/routes/solid-start/reference/entrypoints/data.json
@@ -1,0 +1,6 @@
+{
+	"title": "Entrypoints",
+	"pages": ["app-config.mdx", "app.mdx", "entry-client.mdx", "entry-server.mdx"]
+}
+
+

--- a/src/routes/solid-start/reference/entrypoints/entry-client.mdx
+++ b/src/routes/solid-start/reference/entrypoints/entry-client.mdx
@@ -1,0 +1,47 @@
+---
+title: entry-client.tsx
+---
+
+
+`entry-client.tsx` is where your app starts in the browser.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { mount, StartClient } from "@solidjs/start/client";
+
+mount(() => <StartClient />, document.getElementById("app")!);
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Mounting your application
+
+This file does one thing. It starts your SolidStart application in the browser. It does so by passing in our `<StartClient>` to a `mount` function that also takes our mount element as an argument. What is `mount`? It is an alias over Solid's `hydrate` and `render` methods to ensure that no matter what the client always starts up properly.
+
+It doesn't matter if you are using SolidStart to do client-only rendering or if you are using our various modes of server-side rendering. This file is good place to run any other client specific code that you want to happen on startup. Things like registering service workers.
+
+## Reference
+
+### `mount(codeFn, mountEl)`
+
+Method that either calls `render` or `hydrate` depending on the configuration.
+
+```tsx twoslash
+import { mount, StartClient } from "@solidjs/start/client";
+
+mount(() => <StartClient />, document.getElementById("app")!);
+```
+
+#### Parameters
+
+- `codeFn` (_function_): function that executes the application code
+- `mountEl` (_Node_ | _Document_): element to mount the application to
+
+### `<StartClient />`
+
+Component that wraps our application root.

--- a/src/routes/solid-start/reference/entrypoints/entry-server.mdx
+++ b/src/routes/solid-start/reference/entrypoints/entry-server.mdx
@@ -1,0 +1,50 @@
+---
+title: entry-server.tsx
+---
+
+`entry-server.tsx` is where your app starts on the server.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { createHandler, StartServer } from "@solidjs/start/server";
+
+export default createHandler(() => (
+  <StartServer
+    document={({ assets, children, scripts }) => (
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <link rel="icon" href="/favicon.ico" />
+          {assets}
+        </head>
+        <body>
+          <div id="app">{children}</div>
+          {scripts}
+        </body>
+      </html>
+    )}
+  />
+));
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Rendering your application
+
+This file does one thing. It starts your SolidStart application on the server. It does so by passing in our `<StartServer>` to a "render" function. `<StartServer>` takes a document component which will serve as the static document for your application.
+
+## Reference
+
+### `createHandler(renderFn, options)`
+
+This calls the underlying Solid render function, and passes the options to it.
+
+### `<StartServer document={document} />`
+
+Component that wraps our application root.

--- a/src/routes/solid-start/reference/router/FileRoutes.mdx
+++ b/src/routes/solid-start/reference/router/FileRoutes.mdx
@@ -1,0 +1,50 @@
+---
+title: FileRoutes
+---
+
+`FileRoutes` is a component that renders a [`Route`][route] for each file in the `routes` directory.
+
+<div class="text-lg">
+
+```tsx twoslash
+import { FileRoutes } from "@solidjs/start/router";
+<FileRoutes />;
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Using file-based routing to set up your `Routes`
+
+The `<FileRoutes>` component collects routes from the file-system in the `/routes` folder to be inserted into a parent `<Routes>` component.
+
+Since `FileRoutes` returns a route configuration, it must be placed directly inside a `<Routes>`, usually the one in your `root.tsx` file.
+
+```tsx twoslash {7-9} filename="app.tsx"
+import { Suspense } from "solid-js";
+import { Router } from "@solidjs/router";
+import { FileRoutes } from "@solidjs/start/router";
+
+export default function App() {
+  return (
+    <Router root={props => <Suspense>{props.children}</Suspense>}>
+      <FileRoutes />
+    </Router>
+  );
+}
+```
+
+<aside>
+
+Be careful before you decide to remove the `FileRoutes` component from your `app.tsx` file. If you do, you will need to manually add all of your routes to the `<Routes>` component.
+
+You will still lose out on some optimizations that are enabled by file-system routing like preloaded script tags. While we will caution you however, always be free to explore what you can do.
+
+</aside>
+
+See the [routing guide](/core-concepts/routing) for more details.
+
+[route]: /api/Route

--- a/src/routes/solid-start/reference/router/data.json
+++ b/src/routes/solid-start/reference/router/data.json
@@ -1,0 +1,4 @@
+{
+	"title": "Router",
+	"pages": ["FileRoutes.mdx"]
+}

--- a/src/routes/solid-start/reference/server/GET.mdx
+++ b/src/routes/solid-start/reference/server/GET.mdx
@@ -1,0 +1,21 @@
+---
+title: GET
+---
+
+`GET` allows one to create a server function which is accessed via an [HTTP GET request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET). When this function is called, the arguments are serialized into the url, thus allowing the use of [HTTP cache-control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) headers.
+
+## Usage
+Example with streaming promise and a 60 second cache life
+
+```tsx twoslash {4, 8}
+import { json } from "@solidjs/router";
+import { GET } from "@solidjs/start";
+
+const hello = GET(async (name: string) => {
+  "use server";
+  return json(
+    { hello: new Promise<string>(r => setTimeout(() => r(name), 1000)) },
+    { headers: { "cache-control": "max-age=60" } }
+  );
+});
+```

--- a/src/routes/solid-start/reference/server/RequestEvent.mdx
+++ b/src/routes/solid-start/reference/server/RequestEvent.mdx
@@ -1,0 +1,69 @@
+---
+title: RequestEvent
+---
+
+Solid uses Async Local Storage on the server as a way of injecting the request context anywhere on the server. This is also the event that shows up in middleware.
+
+It can be retrieved via the `getRequestEvent` call from `"solid-js/web"`. That is right the core event is available in libraries as well but we extend it for SolidStart's purposes.
+
+```js
+import { getRequestEvent } from "solid-js/web";
+
+const event = getRequestEvent();
+```
+
+## Request
+
+The most important property of the `RequestEvent` is `.request`. This is a Web [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object that represents the current request to the server. You can access all the properties off of it like `url` and `headers`. The `body` usually does not need to be handled directly for things like server functions or rendering which already handle mapping it.
+
+```js
+import { getRequestEvent } from "solid-js/web";
+
+const event = getRequestEvent();
+if (event) {
+  const auth = event.request.headers.get("Authorization")
+}
+```
+
+## Response
+
+The `RequestEvent` also can be used to stub out the Response. We extend the options that one would pass to the [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#options) constructor. This is kept up to date so it can be used to read and write headers and status for the current response.
+
+```js
+import { getRequestEvent } from "solid-js/web";
+
+const event = getRequestEvent();
+if (event) {
+  event.response.headers.append("Set-Cookie", "foo=hello");
+  event.response.status = 201;
+}
+```
+
+### Returning a Response vs updating the Response on the event
+
+The event is considered global and lasts the life of the request. Therefore whether you are calling a server function on the server during SSR or via an RPC call setting values on `event.response` will reflect on that request.
+
+Whereas the returned response will only impact the response when it is an RPC call. This is important because some headers you might want to set you may not want to set for the whole page and only for the specific request.
+
+Keep this in mind when choosing where to set headers and responses.
+
+## Locals
+
+SolidStart uses `event.locals` to pass around local context to be used as you see fit.
+
+When adding fields to `event.locals`, you can let Typescript know the types of these fields like so:
+
+```tsx
+declare module "@solidjs/start/server" {
+  interface RequestEventLocals {
+    myNumber: number;
+    someString: string;
+  }
+}
+```
+
+## nativeEvent
+
+Sometimes you still need access to the underlying event from Vinxi. You can access that using the `.nativeEvent` property. It is the underlying H3Event used and can be passed to the helpers available in the ecosystem. Keep in mind that Vinxi HTTP helpers do not treeshake so you can only import them in files that do not contain client or isomorphic code.
+
+Many of these events support Async Local Storage so this may not be needed.

--- a/src/routes/solid-start/reference/server/ReturnResponses.mdx
+++ b/src/routes/solid-start/reference/server/ReturnResponses.mdx
@@ -1,0 +1,56 @@
+---
+title: Returning Responses
+---
+
+In SolidStart it's possible to return a Response object from a server function. `@solidjs/router` knows how to handle certain responses with its `cache` and `action` APIs. For Typescript ergonomics, when returning a response using `@solidjs/router`'s `redirect`, `reload`, or `json` helpers, they will not impact the return value of the server function.
+
+You can always return or throw a response but we suggest that depending on the type of function to handle errors differently.
+
+```html
+<table>
+  <th><td>cache</td><td>action</td><th>
+  <tr><td>return</td><td>data, response</td><td>success message, error, response</td></tr>
+  <tr><td>throw</td><td>error, response</td><td>response</td></tr>
+</table>
+```
+
+## Examples
+
+In the following example, as far as Typescript is concerned, the `hello` function will return a value of type `Promise<{ hello: Promise<string> }>`
+
+```tsx twoslash
+import { json } from "@solidjs/router";
+import { GET } from "@solidjs/start";
+
+const hello = GET(async (name: string) => {
+  "use server";
+  return json(
+    { hello: new Promise<string>(r => setTimeout(() => r(name), 1000)) },
+    { headers: { "cache-control": "max-age=60" } }
+  );
+});
+```
+<br />
+
+In this next example, because `redirect` and `reload` return `never` that means the `getUser` function can only return a value of type `Promise<User>`
+
+```tsx { 4, 10, 14}
+export async function getUser() {
+  "use server"
+
+  const session = await getSession();
+  const userId = session.data.userId;
+  if (userId === undefined) return redirect("/login");
+
+  try {
+    const user: User = await db.user.findUnique({ where: { id: userId } });
+
+    // throwing here could have been a bit awkward.
+    if (!user) return redirect("/login");
+    return user;
+  } catch {
+    // do stuff
+    throw redirect("/login");
+  }
+}
+```

--- a/src/routes/solid-start/reference/server/clientOnly.mdx
+++ b/src/routes/solid-start/reference/server/clientOnly.mdx
@@ -1,0 +1,47 @@
+---
+title: clientOnly
+---
+
+Wrap Components that are only to be rendered in the Client. Helpful for components that can never server render because they interact directly with the DOM. It works similar to `lazy` except it only renders after hydration and never loads on the Server.
+
+<div class="text-lg">
+
+```tsx
+import { clientOnly } from "@solidjs/start";
+
+const ClientOnlyComp = clientOnly(() => import("../ClientOnlyComp"));
+
+function IsomorphicComp() {
+  return <ClientOnlyComp />;
+}
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Basic usage
+
+You may have a component that has some sort of client based side effect like writing or reading something from the document. Maybe some legacy jQuery code etc. To use `clientOnly` first isolate the code in a file.
+
+```tsx twoslash
+const location = window.document.location;
+
+export default function ClientOnlyComponent() {
+  return <div>{location.href}</div>;
+}
+```
+
+And then import dynamically using `clientOnly`.
+
+```tsx
+import { clientOnly } from "@solidjs/start";
+
+const ClientOnlyComp = clientOnly(() => import("../ClientOnlyComp"));
+
+function IsomorphicComp() {
+  return <ClientOnlyComp />;
+}
+```

--- a/src/routes/solid-start/reference/server/data.json
+++ b/src/routes/solid-start/reference/server/data.json
@@ -1,0 +1,4 @@
+{
+	"title": "Server",
+	"pages": ["clientOnly.mdx", "GET.mdx", "RequestEvent.mdx", "ReturnResponses.mdx", "server.mdx" ]
+}

--- a/src/routes/solid-start/reference/server/server.mdx
+++ b/src/routes/solid-start/reference/server/server.mdx
@@ -1,0 +1,63 @@
+---
+title: use server
+---
+
+Perform actions on the server environment only (i.e. console logging, etc.).
+
+<div class="text-lg">
+
+```tsx twoslash
+// ---cut---
+const logHello = async (message: string) => {
+  "use server";
+  console.log(message);
+};
+```
+
+</div>
+
+<table-of-contents></table-of-contents>
+
+## Usage
+
+### Basic usage
+
+To create a function that only runs on the server, insert `"use server"` directive at the top of the function.
+
+```tsx twoslash {2}
+const logHello = async (message: string) => {
+  "use server";
+  console.log(message);
+};
+
+logHello("Hello");
+```
+
+In this example, regardless of whether we are rendering this on the server or in the browser, the `logHello` function generates a log on the server console only. How does it work? We use compilation to transform the `use server` function into an RPC call to the server.
+
+### Serialization
+
+Server functions allow the serialization of many different data types in the response. The full list is available [here](https://github.com/lxsmnsyc/seroval/blob/main/docs/compatibility.md#supported-types).
+
+### Meta information
+
+Depending on your hosting, the server function might be running in parallel on multiple cpu cores or workers. You can use `getServerFunctionMeta` to retrieve a function-specific `id`, which is stable across all instances. 
+
+Keep in mind: this `id` can and will change between builds!
+
+```tsx twoslash
+import { getServerFunctionMeta } from "@solidjs/start/server";
+
+// or some in-memory db
+const appCache: any = globalThis;
+
+const counter = async () => {
+  "use server";
+  const { id } = getServerFunctionMeta()!;
+  const key = `counter_${id}`;
+  appCache[key] = appCache[key] ?? 0;
+  appCache[key]++;
+
+  return appCache[key] as number;
+};
+```


### PR DESCRIPTION
Direct move of the solid start reference section, to the new syntax. (Header link still  disabled for now)

There are section here I don't consider fully reference like "Returning responses", but it can be improved on the new site.

<img width="567" alt="Screenshot 2024-03-18 at 00 39 37" src="https://github.com/solidjs/solid-docs-next/assets/74932975/23b23baf-0ddc-4a97-9e0c-027a49eb32b5">
