### PR TITLE
fix light mode links

### DIFF
--- a/src/ui/markdown-components.tsx
+++ b/src/ui/markdown-components.tsx
@@ -146,7 +146,7 @@ export default {
 			return (
 				<A
 					addLocale
-					class={`no-underline shadow-[inset_0_-2px_0_0_var(--tw-prose-background,#38bdf8),inset_0_calc(-1*(var(--tw-prose-underline-size,2px)+2px))_0_0_var(--tw-prose-underline,theme(colors.blue.400))] hover:[--tw-prose-underline-size:4px] dark:[--tw-prose-background:theme(colors.slate.900)] dark:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.blue.500))] dark:hover:[--tw-prose-underline-size:6px] dark:text-blue-300 text-blue-800 font-semibold`}
+					class={`no-underline shadow-[inset_0_calc(-1*(var(--tw-prose-underline-size,0.5px)+2px))_0_0_var(--tw-prose-underline,theme(colors.blue.400))] hover:[--tw-prose-underline-size:4px] dark:[--tw-prose-background:theme(colors.slate.900)] [--tw-prose-background:theme(colors.slate.50)] dark:shadow-[inset_0_calc(-1*var(--tw-prose-underline-size,2px))_0_0_var(--tw-prose-underline,theme(colors.blue.500))] dark:hover:[--tw-prose-underline-size:6px] dark:text-blue-300 text-blue-800 font-semibold`}
 					{...rest}
 				>
 					{resolved()}


### PR DESCRIPTION
closes #597 

Before:

<img width="621" alt="Screenshot 2024-03-18 at 23 24 12" src="https://github.com/solidjs/solid-docs-next/assets/74932975/d26c8953-4d8f-4007-a18a-ab7182ca1fbc">
<img width="606" alt="Screenshot 2024-03-18 at 23 24 32" src="https://github.com/solidjs/solid-docs-next/assets/74932975/c72e9013-79e3-48b2-833a-f7ec995ec92b">


After


<img width="435" alt="Screenshot 2024-03-18 at 23 18 41" src="https://github.com/solidjs/solid-docs-next/assets/74932975/ac04f4e0-4bec-41ab-91a1-4a4cd4c4413b">
<img width="437" alt="Screenshot 2024-03-18 at 23 19 10" src="https://github.com/solidjs/solid-docs-next/assets/74932975/1e6099ae-ab71-4c7a-932f-d7c7df8afe23">
<img width="435" alt="Screenshot 2024-03-18 at 23 18 26" src="https://github.com/solidjs/solid-docs-next/assets/74932975/4f19a228-7edd-4016-86cb-018a27be3a3a">
<img width="434" alt="Screenshot 2024-03-18 at 23 19 19" src="https://github.com/solidjs/solid-docs-next/assets/74932975/c1d22327-7111-4138-ad6b-f91a6805e2a2">
