### PR TITLE
fix: custom native scrollbar on light theme is using the dark theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -25,7 +25,7 @@
 		scrollbar-width: thin;
 	}
 	html.dark,
-	.custom-scrollbar {
+	html.dark .custom-scrollbar {
 		scrollbar-color: #8a99ae #313c50;
 		scrollbar-width: thin;
 	}


### PR DESCRIPTION
for custom scrollbars, when the scrollbar is native (for example the menu scroll on mac, or the menu scroll on firefox) the light theme is using the dark theme. Somehow nobody noticed till now xD I just got a poke about it.