### PR TITLE
Virtual modules cleanup

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -15,6 +15,10 @@ import pkg from "@vinxi/plugin-mdx";
 const { default: vinxiMdx } = pkg;
 import tree from "./.solid/tree";
 import entries from "./.solid/flat-entries";
+import solidstartEntries from "./.solid/solid-start-flat-entries";
+import solidstartTree from "./.solid/solid-router-tree";
+import solidrouterEntries from "./.solid/solid-router-flat-entries";
+import solidrouterTree from "./.solid/solid-start-tree";
 
 function docsTree() {
 	const virtualModuleId = "solid:collection/tree";
@@ -29,7 +33,11 @@ function docsTree() {
 		},
 		async load(id: string) {
 			if (id === resolveVirtualModuleId) {
-				return `export default ${JSON.stringify(tree, null, 2)}`;
+				return `
+				export const coreTree = ${JSON.stringify(tree, null, 2)}
+				export const routerTree = ${JSON.stringify(solidrouterTree, null, 2)}
+				export const startTree = ${JSON.stringify(solidstartEntries, null, 2)}
+				`;
 			}
 		},
 	};
@@ -48,7 +56,11 @@ function docsEntries() {
 		},
 		async load(id: string) {
 			if (id === resolveVirtualModuleId) {
-				return `export default ${JSON.stringify(entries, null, 2)}`;
+				return `
+				export const coreEntries = ${JSON.stringify(entries, null, 2)}
+				export const routerEntries = ${JSON.stringify(solidrouterEntries, null, 2)}
+				export const startEntries = ${JSON.stringify(solidstartEntries, null, 2)}
+				`;
 			}
 		},
 	};

--- a/app.config.ts
+++ b/app.config.ts
@@ -16,39 +16,16 @@ const { default: vinxiMdx } = pkg;
 import tree from "./.solid/tree";
 import entries from "./.solid/flat-entries";
 import solidstartEntries from "./.solid/solid-start-flat-entries";
-import solidstartTree from "./.solid/solid-router-tree";
 import solidrouterEntries from "./.solid/solid-router-flat-entries";
-import solidrouterTree from "./.solid/solid-start-tree";
+import solidrouterTree from "./.solid/solid-router-tree";
+import solidStartTree from "./.solid/solid-start-tree";
 
-function docsTree() {
-	const virtualModuleId = "solid:collection/tree";
+function docsData() {
+	const virtualModuleId = "solid:collection";
 	const resolveVirtualModuleId = "\0" + virtualModuleId;
 
 	return {
-		name: "solid:collection/tree",
-		resolveId(id: string) {
-			if (id === virtualModuleId) {
-				return resolveVirtualModuleId;
-			}
-		},
-		async load(id: string) {
-			if (id === resolveVirtualModuleId) {
-				return `
-				export const coreTree = ${JSON.stringify(tree, null, 2)}
-				export const routerTree = ${JSON.stringify(solidrouterTree, null, 2)}
-				export const startTree = ${JSON.stringify(solidstartEntries, null, 2)}
-				`;
-			}
-		},
-	};
-}
-
-function docsEntries() {
-	const virtualModuleId = "solid:collection/flat-entries";
-	const resolveVirtualModuleId = "\0" + virtualModuleId;
-
-	return {
-		name: "solid:collection/flat-entries",
+		name: "solid:collection",
 		resolveId(id: string) {
 			if (id === virtualModuleId) {
 				return resolveVirtualModuleId;
@@ -60,6 +37,9 @@ function docsEntries() {
 				export const coreEntries = ${JSON.stringify(entries, null, 2)}
 				export const routerEntries = ${JSON.stringify(solidrouterEntries, null, 2)}
 				export const startEntries = ${JSON.stringify(solidstartEntries, null, 2)}
+				export const coreTree = ${JSON.stringify(tree, null, 2)}
+				export const routerTree = ${JSON.stringify(solidrouterTree, null, 2)}
+				export const startTree = ${JSON.stringify(solidStartTree, null, 2)}
 				`;
 			}
 		},
@@ -80,8 +60,7 @@ export default defineConfig({
 	extensions: ["mdx", "md", "tsx"],
 	vite: () => ({
 		plugins: [
-			docsTree(),
-			docsEntries(),
+			docsData(),
 			vinxiMdx.withImports({})({
 				define: {
 					"import.meta.env": `'import.meta.env'`,

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,11 +1,15 @@
 declare module "solid:collection/tree" {
-	import tree from ".solid/tree";
+	import coreTree from ".solid/tree";
+	import startTree from ".solid/solid-router-tree";
+	import routerTree from ".solid/solid-start-tree";
 	// eslint-disable-next-line
-	export default tree;
+	export { coreTree, routerTree, startTree };
 }
 
 declare module "solid:collection/flat-entries" {
-	import entries from ".solid/flat-entries";
-	// eslint-disable-next-line
-	export default entries;
+	import coreEntries from ".solid/flat-entries";
+	import routerEntries from ".solid/solid-start-flat-entries";
+	import startEntries from ".solid/solid-router-flat-entries";
+
+	export { coreEntries, routerEntries, startEntries };
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,15 +1,17 @@
-declare module "solid:collection/tree" {
+declare module "solid:collection" {
 	import coreTree from ".solid/tree";
 	import startTree from ".solid/solid-router-tree";
 	import routerTree from ".solid/solid-start-tree";
-	// eslint-disable-next-line
-	export { coreTree, routerTree, startTree };
-}
-
-declare module "solid:collection/flat-entries" {
 	import coreEntries from ".solid/flat-entries";
 	import routerEntries from ".solid/solid-start-flat-entries";
 	import startEntries from ".solid/solid-router-flat-entries";
 
-	export { coreEntries, routerEntries, startEntries };
+	export {
+		coreEntries,
+		routerEntries,
+		startEntries,
+		coreTree,
+		routerTree,
+		startTree,
+	};
 }

--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -2,8 +2,6 @@
 title: "Overview"
 ---
 
-# Overview
-
 SolidStart is an open source, meta-framework that provides the platform to put components that comprise a web application together.
 It is built on top of powered by [SolidJS](/) and uses [Vinxi](https://vinxi.vercel.app/), an agnostic Framework Bundler that combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io/).
 
@@ -25,8 +23,8 @@ A driving principle of SolidStart is that code should be _isomorphic_ &mdash; th
 SolidStart features the following capabilities:
 
 - **Fine-grained reactivity** &mdash; Powered by SolidJS and it's fine-grained reactivity.
-- **Isomorphic, nested routing** &mdash; The same routes are rendered regardless of whether the page is on the client or server. 
-Route nesting provides parent-child relationships that simplify application logic.
+- **Isomorphic, nested routing** &mdash; The same routes are rendered regardless of whether the page is on the client or server.
+  Route nesting provides parent-child relationships that simplify application logic.
 - **Multiple rendering modes** &mdash; Can be used to create CSR, SSR (Sync, Async and Streaming), and SSG applications.
 - **Command Line Interface (CLI) and templates** &mdash; Provides a CLI and templates to help you get started quickly.
 - **Deployment presets** &mdash; Provides presets to support deployment to multiple platforms including Netlify, Vercel, AWS, and Cloudflare.

--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -2,6 +2,8 @@
 title: "Overview"
 ---
 
+# Overview
+
 SolidStart is an open source, meta-framework that provides the platform to put components that comprise a web application together.
 It is built on top of powered by [SolidJS](/) and uses [Vinxi](https://vinxi.vercel.app/), an agnostic Framework Bundler that combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io/).
 

--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -1,7 +1,7 @@
 import { createSignal, Show, onMount, JSX } from "solid-js";
 import { useLocation, useMatch } from "@solidjs/router";
 import { Title } from "@solidjs/meta";
-import { coreEntries } from "solid:collection/flat-entries";
+import { coreEntries } from "solid:collection";
 import { Pagination } from "~/ui/pagination";
 import { EditPageLink } from "./edit-page-link";
 import { PageIssueLink } from "./page-issue-link";
@@ -40,7 +40,7 @@ export const DocsLayout = (props: DocsLayoutProps) => {
 	onMount(() => document.dispatchEvent(new CustomEvent("docs-layout-mounted")));
 
 	return (
-		<Show when={props.entries}>
+		<Show when={props.entries} keyed>
 			<>
 				<Show when={titles()?.title} fallback={<Title>SolidDocs</Title>}>
 					{(title) => <Title>{`${title()} - SolidDocs`}</Title>}

--- a/src/ui/docs-layout.tsx
+++ b/src/ui/docs-layout.tsx
@@ -1,7 +1,7 @@
 import { createSignal, Show, onMount, JSX } from "solid-js";
 import { useLocation, useMatch } from "@solidjs/router";
 import { Title } from "@solidjs/meta";
-import flatEntries from "solid:collection/flat-entries";
+import { coreEntries } from "solid:collection/flat-entries";
 import { Pagination } from "~/ui/pagination";
 import { EditPageLink } from "./edit-page-link";
 import { PageIssueLink } from "./page-issue-link";
@@ -9,16 +9,12 @@ import { PageIssueLink } from "./page-issue-link";
 export const [trackHeading, setTrackHeading] = createSignal("");
 
 interface DocsLayoutProps {
-	entries: typeof flatEntries;
+	entries: typeof coreEntries;
 	children: JSX.Element;
 }
 
 export const DocsLayout = (props: DocsLayoutProps) => {
 	const location = useLocation();
-	// const isReference = useMatch(() => "/reference/*");
-	// const isSubReference = useMatch(() => "/:project/reference", {
-	// 	project: ["solid-router"],
-	// });
 
 	const lastSegmentPath = () => location.pathname.split("/").reverse()[0];
 	const collection = () =>
@@ -44,43 +40,38 @@ export const DocsLayout = (props: DocsLayoutProps) => {
 	onMount(() => document.dispatchEvent(new CustomEvent("docs-layout-mounted")));
 
 	return (
-		<Show when={props.entries} keyed>
-			{(e) => (
-				<>
-					<Show when={titles()?.title} fallback={<Title>SolidDocs</Title>}>
-						{(title) => <Title>{`${title()} - SolidDocs`}</Title>}
-					</Show>
-					<div id="rr" class="flex relative justify-center">
-						<article class="w-fit overflow-hidden px-2 pb-16 md:px-10 expressive-code-overrides lg:max-w-none lg:min-w-[65ch]">
-							<Show when={titles()?.parent}>
-								{(t) => (
-									<span class="text-sm font-semibold text-blue-700 dark:text-blue-300 my-1">
-										{t()}
-									</span>
-								)}
-							</Show>
-							<Show when={titles()?.title}>
-								{(t) => (
-									<h1 class="prose-headings:text-[2.8rem] text-slate-900 dark:text-white">
-										{t()}
-									</h1>
-								)}
-							</Show>
-							<span class="xl:hidden text-sm -mt-[15px] block">
-								<EditPageLink />
-							</span>
-							<div class="max-w-prose w-full">{props.children}</div>
-							<span class="xl:hidden text-sm">
-								<PageIssueLink />
-							</span>
-							<Pagination
-								currentIndex={entryIndex()}
-								collection={collection()}
-							/>
-						</article>
-					</div>
-				</>
-			)}
+		<Show when={props.entries}>
+			<>
+				<Show when={titles()?.title} fallback={<Title>SolidDocs</Title>}>
+					{(title) => <Title>{`${title()} - SolidDocs`}</Title>}
+				</Show>
+				<div id="rr" class="flex relative justify-center">
+					<article class="w-fit overflow-hidden px-2 pb-16 md:px-10 expressive-code-overrides lg:max-w-none lg:min-w-[65ch]">
+						<Show when={titles()?.parent}>
+							{(t) => (
+								<span class="text-sm font-semibold text-blue-700 dark:text-blue-300 my-1">
+									{t()}
+								</span>
+							)}
+						</Show>
+						<Show when={titles()?.title}>
+							{(t) => (
+								<h1 class="prose-headings:text-[2.8rem] text-slate-900 dark:text-white">
+									{t()}
+								</h1>
+							)}
+						</Show>
+						<span class="xl:hidden text-sm -mt-[15px] block">
+							<EditPageLink />
+						</span>
+						<div class="max-w-prose w-full">{props.children}</div>
+						<span class="xl:hidden text-sm">
+							<PageIssueLink />
+						</span>
+						<Pagination currentIndex={entryIndex()} collection={collection()} />
+					</article>
+				</div>
+			</>
 		</Show>
 	);
 };

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -11,11 +11,13 @@ import { SidePanel } from "./layout/side-panel";
 import { SUPPORTED_LOCALES } from "~/i18n/config";
 import { getValidLocaleFromPathname } from "~/i18n/helpers";
 import {
+	coreTree,
+	routerTree,
+	startTree,
 	coreEntries,
 	startEntries,
 	routerEntries,
-} from "solid:collection/flat-entries";
-import { coreTree, routerTree, startTree } from "solid:collection/tree";
+} from "solid:collection";
 import { PathMatch } from "@solidjs/router/dist/types";
 
 const PROJECTS = ["solid-router", "solid-start", "solid-meta"] as const;

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -10,11 +10,37 @@ import { Alert } from "@kobalte/core";
 import { SidePanel } from "./layout/side-panel";
 import { SUPPORTED_LOCALES } from "~/i18n/config";
 import { getValidLocaleFromPathname } from "~/i18n/helpers";
-import flatEntries from "solid:collection/flat-entries";
-import englishNav from "solid:collection/tree";
+import {
+	coreEntries,
+	startEntries,
+	routerEntries,
+} from "solid:collection/flat-entries";
+import { coreTree, routerTree, startTree } from "solid:collection/tree";
 import { PathMatch } from "@solidjs/router/dist/types";
 
-const PROJECTS = ["solid-router", "solid-start", "solid-meta"];
+const PROJECTS = ["solid-router", "solid-start", "solid-meta"] as const;
+
+function getDefaultTree(project: (typeof PROJECTS)[number]) {
+	switch (project) {
+		case "solid-router":
+			return routerTree;
+		case "solid-start":
+			return startTree;
+		default:
+			return coreTree;
+	}
+}
+
+function getDefaultEntries(project: (typeof PROJECTS)[number]) {
+	switch (project) {
+		case "solid-router":
+			return routerEntries;
+		case "solid-start":
+			return startEntries;
+		default:
+			return coreEntries;
+	}
+}
 
 const getProjectFromUrl = (path: string) => {
 	for (const project of PROJECTS) {
@@ -35,8 +61,8 @@ const getDocsMetadata = cache(
 
 		if (!isFirstMatch && !isI18nOrProject)
 			return {
-				tree: englishNav,
-				entries: flatEntries,
+				tree: coreTree,
+				entries: coreEntries,
 			};
 
 		const { path } = (isFirstMatch || isI18nOrProject || isCore) as PathMatch;
@@ -56,9 +82,8 @@ const getDocsMetadata = cache(
 			}
 
 			return {
-				tree: (await import(`../../.solid/${project}-tree.ts`)).default,
-				entries: (await import(`../../.solid/${project}-flat-entries.ts`))
-					.default,
+				tree: getDefaultTree(project),
+				entries: getDefaultEntries(project),
 			};
 		}
 
@@ -70,8 +95,8 @@ const getDocsMetadata = cache(
 			};
 		} else {
 			return {
-				tree: englishNav,
-				entries: flatEntries,
+				tree: coreTree,
+				entries: coreEntries,
 			};
 		}
 	},


### PR DESCRIPTION
This PR centralizes the solid:collection exports in the same virtual barrel file.

It also statically import the trees and entries for all projects in the main language (English), so navigation is likely to be faster between projects. The tradeoff is that client-side bundle gets slightly larger (a few JSON files bigger), but the perf and stability should compensate.