### PR TITLE
Remove redundant phrase on the solid-start overview page

### DIFF
--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -5,7 +5,7 @@ title: "Overview"
 # Overview
 
 SolidStart is an open source, meta-framework that provides the platform to put components that comprise a web application together.
-It is built on top of powered by [SolidJS](/) and uses [Vinxi](https://vinxi.vercel.app/), an agnostic Framework Bundler that combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io/).
+It is built on top of [SolidJS](/) and uses [Vinxi](https://vinxi.vercel.app/), an agnostic Framework Bundler that combines the power of [Vite](https://vitejs.dev) and [Nitro](https://nitro.unjs.io/).
 
 Start avoids being opinionated by only providing the fewest amount of pieces to get you started.
 While templates are available that include many of the expected tools, SolidStart itself does not ship with a Router or Metadata library.


### PR DESCRIPTION
Removes the redundant phrase "powered by" on the solid-start overview page