### PR TITLE
[Content] MemoryRouter reference page

### DIFF
--- a/src/routes/solid-router/concepts/alternative-routers.mdx
+++ b/src/routes/solid-router/concepts/alternative-routers.mdx
@@ -17,7 +17,7 @@ import { HashRouter } from "@solidjs/router";
 
 ## Memory Mode Router
 
-You can also use memory mode router for testing purpose.
+You can also use [`MemoryRouter`](/solid-router/reference/components/memory-router) for testing purpose.
 
 ```jsx
 import { MemoryRouter } from "@solidjs/router";

--- a/src/routes/solid-router/reference/components/data.json
+++ b/src/routes/solid-router/reference/components/data.json
@@ -1,4 +1,4 @@
 {
 	"title": "Components",
-	"pages": ["router.mdx", "hash-router.mdx", "route.mdx", "a.mdx", "navigate.mdx"]
+	"pages": ["router.mdx", "hash-router.mdx", "memory-router.mdx", "route.mdx", "a.mdx", "navigate.mdx"]
 }

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -2,8 +2,8 @@
 title: MemoryRouter
 ---
 
-The `MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
-Other routers keep the history externally i.e. in the url like the `<HashRouter>` or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
+The `MemoryRouter` can be used to route while keeping the entire routing history within internal memory.
+Other routers keep history externally such as in the url like the [`<HashRouter>`](/solid-router/reference/components/hash-router) or in the browser history like [`<Router>`](/solid-router/reference/components/memory-router).
 
 Keeping the history in memory is useful when you want full control over the routing history.
 Since `MemoryRouter` can manipulate `MemoryHistory`, it is often used for testing purposes.

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -41,7 +41,7 @@ In this example, a history object is pre-filled to navigate to the `/about` rout
 
 ## Manipulating the history
 
-The `MemoryHistory` object has the following functions, which are used to control the navigation:
+The `MemoryHistory` object contains functions that are used to control navigation. 
 
 ### get
 

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -5,8 +5,8 @@ title: MemoryRouter
 The `MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
 Other routers keep the history externally i.e. in the url like the `<HashRouter>` or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
 
-Keeping the history in memory is desirable when you want full control over the routing history.
-The MemoryRouter is therefore often used for testing purposes, where it's controlled through manipulating the `MemoryHistory`.
+Keeping the history in memory is useful when you want full control over the routing history.
+Since `MemoryRouter` can manipulate `MemoryHistory`, it is often used for testing purposes.
 
 In the example below, a history object pre-filled with a navigation to the `/about` route is passed to the `MemoryRouter`.
 

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -8,10 +8,6 @@ Other routers keep history externally such as in the url like the [`<HashRouter>
 Keeping the history in memory is useful when you want full control over the routing history.
 Since `MemoryRouter` can manipulate `MemoryHistory`, it is often used for testing purposes.
 
-In the example below, a history object pre-filled with a navigation to the `/about` route is passed to the `MemoryRouter`.
-
-
-
 ```jsx
 import { MemoryRouter, createMemoryHistory, A } from "@solidjs/router";
 import { Suspense } from "solid-js";

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -4,7 +4,7 @@ title: MemoryRouter
 
 The `MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
 
-Other routers keep the history externally i.e. in the url like the [`<HashRouter>`](/solid-router/reference/components/hash-router) or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
+Other routers keep the history externally i.e. in the url like the `<HashRouter>` or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
 
 Keeping the history in memory is desirable when you want full control over the routing history.
 

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -2,7 +2,7 @@
 title: MemoryRouter
 ---
 
-`MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
+The `MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
 
 Other routers keep the history externally i.e. in the url like the [`<HashRouter>`](/solid-router/reference/components/hash-router) or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
 

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -3,14 +3,14 @@ title: MemoryRouter
 ---
 
 The `MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
-
 Other routers keep the history externally i.e. in the url like the `<HashRouter>` or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
 
 Keeping the history in memory is desirable when you want full control over the routing history.
-
 The MemoryRouter is therefore often used for testing purposes, where it's controlled through manipulating the `MemoryHistory`.
 
 In the example below, a history object pre-filled with a navigation to the `/about` route is passed to the `MemoryRouter`.
+
+
 
 ```jsx
 import { MemoryRouter, createMemoryHistory, A } from "@solidjs/router";

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -37,67 +37,35 @@ export default function App() {
 	);
 }
 ```
+
 In this example, a history object is pre-filled to navigate to the `/about` route, which is then passed to the `MemoryRouter`.
 
 ## Manipulating the history
 
-The `MemoryHistory` object contains functions that are used to control navigation. 
+The `MemoryHistory` object contains the following methods, which you can use to control the navigation of your app.
 
-### get
+- The `get` method retrieves the current route as a string, while the `set` method navigates to a new route, allowing for optional parameters like replacing the current history entry or scrolling to a DOM element id.
+- The `back` and `forward` methods mimic the browser's back and forward buttons, respectively, and the `go` method navigates a specific number of steps in the history, either backward or forward.
+- The `listen` method registers a callback to be called on navigation change.
 
-Returns the current route.
 
-```ts
-get(): string;
-```
-
-### set
-
-Used to navigate to a new route.
-
-- `value` is the url to navigate to.
-- `scroll` determines if the page should scroll to an HTML element with an id matching a hash value in the URL. Default value: `false`
-- `replace` determines if the navigation should replace the current history entry, or make a new. Default value: `false`
-
-```ts
-set({ value: string, scroll?: boolean, replace?: boolean }) => void;
-```
-
-### back
-
-Navigates 1 step back in the history. Corresponds to `go(-1)`.
-
-```ts
-back(): void;
-```
-
-### forward
-
-Navigates 1 step forward in the history. Corresponds to `go(1)`.
-
-```ts
-forward(): void;
-```
-
-### go
-
-Navigates n steps in the history. Negative numbers navigate back, positive numbers navigate forward. It's clamped to the history length, so additional steps will be ignored.
-
-```ts
-go(n: number): void;
-```
-
-### listen
-
-Registers a listener that will be called on navigation.
-
-```ts
-listen(listener: (value: string) => void): () => void;
-```
 
 ## Properties
 
-| prop          | type                                                     | description                                                                                |
+### `MemoryHistory`
+
+| Method    | Signature                                                     | Description                                                                                                                                                                     |
+| --------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get`     | `get(): string`                                               | Returns the current route.                                                                                                                                                      |
+| `set`     | `set({ value: string, scroll?: boolean, replace?: boolean })` | Navigates to a new route. `value`: URL to navigate to. `scroll`: Scrolls to element by ID (default: `false`). `replace`: Replaces the current history entry (default: `false`). |
+| `back`    | `back(): void`                                                | Navigates 1 step back in the history. Corresponds to `go(-1)`.                                                                                                                  |
+| `forward` | `forward(): void`                                             | Navigates 1 step forward in the history. Corresponds to `go(1)`.                                                                                                                |
+| `go`      | `go(n: number): void`                                         | Navigates n steps in the history. Negative for back, positive for forward. Clamped to history length.                                                                           |
+| `listen`  | `listen(listener: (value: string) => void): () => void`       | Registers a listener that will be called on navigation.                                                                                                                         |
+
+### `MemoryRouter`
+
+| Property      | Type                                                     | Description                                                                                |
 | ------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | children      | `JSX.Element`, `RouteDefinition`, or `RouteDefinition[]` | The route definitions                                                                      |
 | root          | Component                                                | Top level layout component                                                                 |

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -37,6 +37,7 @@ export default function App() {
 	);
 }
 ```
+In this example, a history object is pre-filled to navigate to the `/about` route, which is then passed to the `MemoryRouter`.
 
 ## Manipulating the history
 

--- a/src/routes/solid-router/reference/components/memory-router.mdx
+++ b/src/routes/solid-router/reference/components/memory-router.mdx
@@ -1,0 +1,111 @@
+---
+title: MemoryRouter
+---
+
+`MemoryRouter` can be used to route while keeping the entire routing history internally in memory.
+
+Other routers keep the history externally i.e. in the url like the [`<HashRouter>`](/solid-router/reference/components/hash-router) or in the browser history like the [`<Router>`](/solid-router/reference/components/memory-router).
+
+Keeping the history in memory is desirable when you want full control over the routing history.
+
+The MemoryRouter is therefore often used for testing purposes, where it's controlled through manipulating the `MemoryHistory`.
+
+In the example below, a history object pre-filled with a navigation to the `/about` route is passed to the `MemoryRouter`.
+
+```jsx
+import { MemoryRouter, createMemoryHistory, A } from "@solidjs/router";
+import { Suspense } from "solid-js";
+
+export default function App() {
+	const history = createMemoryHistory();
+
+	const toHome = () => {
+		history.set({ value: "/" });
+	};
+	const toAbout = () => {
+		history.set({ value: "/about" });
+	};
+
+	return (
+		<>
+			<button onClick={toHome}>{'"/"'}</button>
+			<button onClick={toAbout}>{'"/about"'}</button>
+
+			<MemoryRouter
+				history={history}
+				root={(props) => <Suspense>{props.children}</Suspense>}
+			>
+				{/*... routes */}
+			</MemoryRouter>
+		</>
+	);
+}
+```
+
+## Manipulating the history
+
+The `MemoryHistory` object has the following functions, which are used to control the navigation:
+
+### get
+
+Returns the current route.
+
+```ts
+get(): string;
+```
+
+### set
+
+Used to navigate to a new route.
+
+- `value` is the url to navigate to.
+- `scroll` determines if the page should scroll to an HTML element with an id matching a hash value in the URL. Default value: `false`
+- `replace` determines if the navigation should replace the current history entry, or make a new. Default value: `false`
+
+```ts
+set({ value: string, scroll?: boolean, replace?: boolean }) => void;
+```
+
+### back
+
+Navigates 1 step back in the history. Corresponds to `go(-1)`.
+
+```ts
+back(): void;
+```
+
+### forward
+
+Navigates 1 step forward in the history. Corresponds to `go(1)`.
+
+```ts
+forward(): void;
+```
+
+### go
+
+Navigates n steps in the history. Negative numbers navigate back, positive numbers navigate forward. It's clamped to the history length, so additional steps will be ignored.
+
+```ts
+go(n: number): void;
+```
+
+### listen
+
+Registers a listener that will be called on navigation.
+
+```ts
+listen(listener: (value: string) => void): () => void;
+```
+
+## Properties
+
+| prop          | type                                                     | description                                                                                |
+| ------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| children      | `JSX.Element`, `RouteDefinition`, or `RouteDefinition[]` | The route definitions                                                                      |
+| root          | Component                                                | Top level layout component                                                                 |
+| base          | string                                                   | Base url to use for matching routes                                                        |
+| actionBase    | string                                                   | Root url for server actions, default: `/_server`                                           |
+| preload       | boolean                                                  | Enables/disables preloads globally, default: `true`                                        |
+| explicitLinks | boolean                                                  | Disables all anchors being intercepted and instead requires `<A>`. default: `false`        |
+| history       | MemoryHistory                                            | An optionally pre-filled and mutable history object which will store any navigation events |


### PR DESCRIPTION
Closes #472
- #472

While creating this, I believe I might have uncovered a bug that makes the MemoryHistory of little use.
- https://github.com/solidjs/solid-router/issues/393

I tested it quite extensively to understand it in depth, and in short what I found is that the `set` function used to navigate to a new route doesn't work well.

I've not had the bug confirmed yet, but it's likely users of MemoryRouter will find themselves debugging almost immediately.

I wrote the Reference as if the functionality is working as intended, and I haven't added a caution box.

Request for review: @LadyBluenotes 