### PR TITLE
[BugFix]: node and pnpm are in list of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
 		"@solidjs/start": "^0.7.5",
 		"@vinxi/plugin-mdx": "^3.7.1",
 		"gray-matter": "^4.0.3",
-		"node": "^21.7.1",
-		"pnpm": "^8.15.5",
 		"postcss": "^8.4.36",
 		"rehype-autolink-headings": "^7.1.0",
 		"rehype-parse": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,6 @@ dependencies:
   gray-matter:
     specifier: ^4.0.3
     version: 4.0.3
-  node:
-    specifier: ^21.7.1
-    version: 21.7.1
-  pnpm:
-    specifier: ^8.15.5
-    version: 8.15.5
   postcss:
     specifier: ^8.4.36
     version: 8.4.36
@@ -5786,10 +5780,6 @@ packages:
     engines: {node: ^16 || ^18 || >= 20}
     dev: false
 
-  /node-bin-setup@1.1.3:
-    resolution: {integrity: sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==}
-    dev: false
-
   /node-fetch-native@1.6.2:
     resolution: {integrity: sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==}
     dev: false
@@ -5818,15 +5808,6 @@ packages:
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
-
-  /node@21.7.1:
-    resolution: {integrity: sha512-j6NFfbKy3DBuaJh2X8lRZmS59oLr2XRtt0rTa9VsFj3ZcGbeK7xp40gZaI92AqNuRv1aL5dRueNqL6YuZFcjJg==}
-    engines: {npm: '>=5.0.0'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      node-bin-setup: 1.1.3
-    dev: false
 
   /nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -6097,12 +6078,6 @@ packages:
       jsonc-parser: 3.2.1
       mlly: 1.6.1
       pathe: 1.1.2
-    dev: false
-
-  /pnpm@8.15.5:
-    resolution: {integrity: sha512-sFGjLH5pWDO4SSbTspuMylclS1ifBknYmcbp0O22cLkex+KkNFm65zdZu1zmGcMmbxFr+THOItHvF1mn5Fqpbw==}
-    engines: {node: '>=16.14'}
-    hasBin: true
     dev: false
 
   /postcss-import@15.1.0(postcss@8.4.36):


### PR DESCRIPTION
Closes #629 
- #629 

We still have:

```json
"engines": {
  "node": ">=18",
  "packageManager": "pnpm@8"
}
```

Request for review: @atilafassina @danieljcafonso 