### PR TITLE
Small CSS fix for the ThemeSelector

### DIFF
--- a/src/ui/layout/theme-selector.tsx
+++ b/src/ui/layout/theme-selector.tsx
@@ -9,7 +9,7 @@ export const ThemeSelector: Component = () => {
 	const setSelectedTheme = ctx.setSelectedTheme;
 	return (
 		<DropdownMenu.Root gutter={10}>
-			<DropdownMenu.Trigger class="flex h-6 w-6 items-center justify-center rounded-lg shadow-md shadow-black/5 ring-1 ring-black/10 dark:bg-slate-800 dark:ring-inset dark:ring-white/60">
+			<DropdownMenu.Trigger class="flex h-6 w-6 items-center justify-center rounded-lg shadow-md shadow-black/5 ring-1 ring-black/10 dark:bg-slate-800 dark:ring-inset dark:ring-white/60 shrink-0">
 				<Icon
 					class="w-4 h-4 fill-slate-700 dark:fill-slate-200"
 					path={selectedTheme()!.icon}


### PR DESCRIPTION
Button for theme shrinks when in mobile and spacing looks off

Before
![CleanShot 2024-04-09 at 14 13 51](https://github.com/solidjs/solid-docs-next/assets/1051509/72d96bff-1370-48e3-b73d-e3e2ec5e274b)

After
![CleanShot 2024-04-09 at 14 13 54](https://github.com/solidjs/solid-docs-next/assets/1051509/cb81b214-3279-486e-860a-3e85d957ce74)
