### PR TITLE
Change "bubbles" to "bubble"

### DIFF
--- a/src/routes/concepts/components/event-handlers.mdx
+++ b/src/routes/concepts/components/event-handlers.mdx
@@ -77,7 +77,7 @@ As a result, there is no requirement for these functions to be reactive.
 ## Event delegation
 
 Instead of attaching event listeners to every individual element, Solid uses _synthetic event delegation_, through the [`on__`](/reference/jsx-attributes/on_) form .
-In this method event listeners are attached to the `document` element, and dispatch events to the relevant elements as they bubbles up.
+In this method event listeners are attached to the `document` element, and dispatch events to the relevant elements as they bubble up.
 
 By keeping the number of event listeners to a minimum, events can be captured more effectively.
 This is especially useful when working with a large number of elements, such as in a table or list.


### PR DESCRIPTION
**Change "bubbles" to "bubble"**

- from: dispatch events to the relevant elements as they bubbles up.
- to: dispatch events to the relevant elements as they bubble up.

**dispatch events**

"In this method event listeners are attached to the `document` element, and dispatch events to the relevant elements as they bubbles up."

This is unclear to me. Is "dispatch events" a thing/noun or is the wording wrong?

Perhaps it should be: 
- ... event listeners are attached to the `document` element, and dispatch**ed** to the relevant elements ...