### PR TITLE
Orama: Remove some `ts-ignore`s and make the searchbox more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@kobalte/core": "^0.12.6",
 		"@lunariajs/core": "^0.0.31",
-		"@orama/searchbox": "1.0.0-rc16",
+		"@orama/searchbox": "1.0.0-rc19",
 		"@oramacloud/client": "^1.0.14",
 		"@solidjs/meta": "^0.29.3",
 		"@solidjs/router": "^0.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^0.0.31
     version: 0.0.31
   '@orama/searchbox':
-    specifier: 1.0.0-rc16
-    version: 1.0.0-rc16(@orama/highlight@0.1.6)(@orama/orama@2.0.14)(@oramacloud/client@1.0.14)(@preact/signals-core@1.6.0)(@preact/signals-react@2.0.1)(@r2wc/react-to-web-component@2.0.3)(react-dom@18.2.0)(react-markdown@9.0.1)(react@18.2.0)(typescript@5.4.2)
+    specifier: 1.0.0-rc19
+    version: 1.0.0-rc19(@orama/highlight@0.1.6)(@orama/orama@2.0.14)(@oramacloud/client@1.0.14)(@preact/signals-core@1.6.0)(@preact/signals-react@2.0.1)(@r2wc/react-to-web-component@2.0.3)(react-dom@18.2.0)(react-markdown@9.0.1)(react@18.2.0)(typescript@5.4.2)
   '@oramacloud/client':
     specifier: ^1.0.14
     version: 1.0.14(typescript@5.4.2)
@@ -1613,8 +1613,8 @@ packages:
       - typescript
     dev: false
 
-  /@orama/searchbox@1.0.0-rc16(@orama/highlight@0.1.6)(@orama/orama@2.0.14)(@oramacloud/client@1.0.14)(@preact/signals-core@1.6.0)(@preact/signals-react@2.0.1)(@r2wc/react-to-web-component@2.0.3)(react-dom@18.2.0)(react-markdown@9.0.1)(react@18.2.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-K9i5lY0BITS/TEA2fgImuREeyFVCBKJrVO51Iv33lyT5C+oMNHEESep449E9FScjJi9A82Wph/+ZXjhP9iIfNw==}
+  /@orama/searchbox@1.0.0-rc19(@orama/highlight@0.1.6)(@orama/orama@2.0.14)(@oramacloud/client@1.0.14)(@preact/signals-core@1.6.0)(@preact/signals-react@2.0.1)(@r2wc/react-to-web-component@2.0.3)(react-dom@18.2.0)(react-markdown@9.0.1)(react@18.2.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-X2BMMBFCXo8p1FeLTi3ms6aGrohXvflxraWWZ3ctex+TADo40R7WJm/0MCpLV4u/61Wyqv7NrReGYUM5v8u6Pw==}
     peerDependencies:
       '@orama/highlight': ^0.1.6
       '@orama/orama': 2.0.14

--- a/src/ui/searchbox.tsx
+++ b/src/ui/searchbox.tsx
@@ -2,6 +2,8 @@ import { isServer } from "solid-js/web";
 import {
 	RegisterSearchBox,
 	RegisterSearchButton,
+	RegisterSearchBoxProps,
+	RegisterSearchButtonProps,
 } from "@orama/searchbox/dist/index.js";
 import { OramaClient } from "@oramacloud/client";
 import { createEffect } from "solid-js";
@@ -69,12 +71,8 @@ export function SearchBox() {
 declare module "solid-js" {
 	namespace JSX {
 		interface IntrinsicElements {
-			/**
-			 * @todo replace `unknown` with the actual type definitions
-			 * that will be exposed from Orama soon-ish.
-			 */
-			"orama-searchbox": unknown;
-			"orama-search-button": unknown;
+			"orama-searchbox": RegisterSearchBoxProps;
+			"orama-search-button": RegisterSearchButtonProps;
 		}
 	}
 }

--- a/src/ui/searchbox.tsx
+++ b/src/ui/searchbox.tsx
@@ -19,6 +19,10 @@ export function SearchBox() {
 
 	if (!isServer) {
 		createEffect(() => {
+			/**
+			 * These function calls create/register web components like
+			 * orama-searchbox and orama-search-button at runtime.
+			 */
 			RegisterSearchBox({
 				summaryGeneration: import.meta.env.VITE_ORAMA_SECURE_PROXY,
 				oramaInstance: client,
@@ -55,11 +59,22 @@ export function SearchBox() {
 	return (
 		<>
 			<div class="fixed z-10">
-				{/* @ts-ignore */}
 				<orama-searchbox />
 			</div>
-			{/* @ts-ignore */}
 			<orama-search-button />
 		</>
 	);
+}
+
+declare module "solid-js" {
+	namespace JSX {
+		interface IntrinsicElements {
+			/**
+			 * @todo replace `unknown` with the actual type definitions
+			 * that will be exposed from Orama soon-ish.
+			 */
+			"orama-searchbox": unknown;
+			"orama-search-button": unknown;
+		}
+	}
 }


### PR DESCRIPTION
This PR cleans up some `@ts-ignore`s and makes the searchbox and search button type safe.

<img width="1912" alt="image" src="https://github.com/solidjs/solid-docs-next/assets/9947422/354ecbb2-9e33-4258-b96f-f65cd26f38b7">
