### PR TITLE
Use Tailwind nesting plugin at the right time

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
 export default {
 	plugins: {
+		"tailwindcss/nesting": {},
 		tailwindcss: {},
 		autoprefixer: {},
 	},
-}
+};


### PR DESCRIPTION
This PR fixes the use of Tailwind's import plugin to fix a warning when running the development server.

|Before|After|
|---|---|
|<img width="1193" alt="image" src="https://github.com/solidjs/solid-docs-next/assets/9947422/f57a388f-5fef-4362-b35d-7283dc87beab">|<img width="1193" alt="image" src="https://github.com/solidjs/solid-docs-next/assets/9947422/f4c88c30-ae1b-474a-8f86-f84c061a2443">|

The further errors in the console in the "After" column come from me not having an Orama API key in my env. Without this, there are no further errors and warnings.