### PR TITLE
Make text match code in css-and-styling.mdx

### DIFF
--- a/src/routes/solid-start/building-your-application/css-and-styling.mdx
+++ b/src/routes/solid-start/building-your-application/css-and-styling.mdx
@@ -95,4 +95,5 @@ const Card = (props) => {
 
 ## Other ways to style components
 
-Because SolidStart is built on top of Solid, styling is not limited to CSS. To see other ways to style components, see the [styling section in the Solid documentation](/guides/styling-your-components).
+SolidStart is built on top of Solid, meaning styling is not limited to CSS. 
+To see other ways to style components, see the [styling section in the Solid documentation](/guides/styling-your-components).

--- a/src/routes/solid-start/building-your-application/css-and-styling.mdx
+++ b/src/routes/solid-start/building-your-application/css-and-styling.mdx
@@ -17,7 +17,7 @@ src/
 │   ├── Card.css
 ```
 
-To use the CSS in the component, you can define the CSS in the `Button.css` file and import it in the `Button.tsx` file:
+To use the CSS in the component, you can define the CSS in the `Card.css` file and import it in the `Card.tsx` file:
 
 ```css title="Card.css"
 .card {


### PR DESCRIPTION
I was just was reading through the documentation and saw this sentence that said you can "define the CSS in the `Button.css` file and import it in the `Button.tsx` file" while showing an example with cards. The buttons are not mentioned anywhere else in the page other than this sentence, and so I've changed it to use the cards example just like the rest of the page.