### PR TITLE
Anchor Node version to `20.x` on GitHub releases

### DIFF
--- a/.github/workflows/orama_sync.yml
+++ b/.github/workflows/orama_sync.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: lts
+        node-version: 20.x
         cache: pnpm
     - uses: pnpm/action-setup@v3
       with:


### PR DESCRIPTION
Linux platform does not have `lts` as a valid alias for Node version