### PR TITLE
Remove duplicated link

### DIFF
--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -120,9 +120,7 @@ You can view it by navigating to [http://localhost:3000](http://localhost:3000).
 <Callout>
     SolidStart uses [Vinxi](https://vinxi.vercel.app/) both for starting a development server with [Vite](https://vitejs.dev/) and for building and starting a production server with [Nitro](https://nitro.unjs.io/).
 
-    When you run your application, you are actually running `vinxi dev` under the hood. 
-    You can read more about the Vinxi CLI, and how it can be configured [here](https://vinxi.vercel.app/api/cli.html).
-
+    When you run your application, you are actually running `vinxi dev` under the hood.
     You can read more about the [Vinxi CLI and how it is configured in the Vinxi documentation](https://vinxi.vercel.app/api/cli.html).
 </Callout>
 


### PR DESCRIPTION
Vinxi CLI documentation was linked twice. I fixed it.