### PR TITLE
Remove node_modules in the Project Files section

### DIFF
--- a/src/routes/solid-start/getting-started.mdx
+++ b/src/routes/solid-start/getting-started.mdx
@@ -133,7 +133,6 @@ These files and directories are the basic structure of a SolidStart application,
 The default structure of a SolidStart application looks like this:
 
 ```
-node_modules/
 public/
 src/
 ├── routes/
@@ -147,7 +146,6 @@ src/
 For example, if you chose to use JavaScript rather than TypeScript, your file extensions will be `.jsx` instead of `.tsx`.
 
 Each directory and file in this structure serves a specific purpose in your SolidStart application:
-- `node_modules/` - this file is where all of your project's dependencies are installed.
 - `public/` - contains the publicly-accessible assets for your application. 
 This is where images, fonts, and other files that you want to be accessible to the public should be placed.
 - `src/` - where your Start application code will live.


### PR DESCRIPTION
`node_modules` is not specific to SolidStart and the users most likely already know what it is. I think it's redundant and removed it. I also checked Next.js and SvelteKit docs and they haven't include `node_modules` in their "Project Structure" section.