### PR TITLE
fix: create a const for the counter object

### DIFF
--- a/src/routes/concepts/context.mdx
+++ b/src/routes/concepts/context.mdx
@@ -241,8 +241,8 @@ import { createSignal, createContext, useContext } from "solid-js";
 const CounterContext = createContext(); // create context
 
 export function CounterProvider(props) {
-	const [count, setCount] = createSignal(props.count || 0),
-	counter = [
+	const [count, setCount] = createSignal(props.count || 0);
+	const counter = [
 		count,
 		{
 			increment() {


### PR DESCRIPTION
In the "Update Context Values" section (https://docs.solidjs.com/concepts/context#updating-context-values), in the snippet for `Context.jsx`, it seems that no variable is being initialized for the counter object. 

Also, I think there's a typo on the line above it. The line ends with a `,` instead of `;`.