### PR TITLE
fix: typo in solid-start overview page

### DIFF
--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -45,7 +45,7 @@ We are working hard to make sure that the APIs are stable and that the framework
 We are also working on improving the documentation and adding more examples to help you get started.
 Over the next few weeks, we will be adding more content to the documentation and improving the overall experience of using SolidStart to get ready for the 1.0 release.
 
-If you experieince any issues while using SolidStart, please let us know by [opening an issue in the SolidStart Repo](https://github.com/solidjs/solid-start/issues).
+If you experience any issues while using SolidStart, please let us know by [opening an issue in the SolidStart Repo](https://github.com/solidjs/solid-start/issues).
 Additionally, if you notice any issues or feel that something is missing in the documentation, please let us know in the [Solid Docs Repo](https://github.com/solidjs/solid-docs-next/issues).
 
 <EditPageLink />


### PR DESCRIPTION
Fixed typo in routes/solid-start/index.mdx

- fix #688 