### PR TITLE
feat: order reference alphabeticaly

### DIFF
--- a/src/ui/layout/main-navigation.tsx
+++ b/src/ui/layout/main-navigation.tsx
@@ -60,7 +60,7 @@ function ListItemLink(props: { item: Entry }) {
 	);
 }
 
-function DirList(props: { list: Entry[] }) {
+function DirList(props: { list: Entry[]; sortAlphabeticaly?: boolean }) {
 	return (
 		<For each={props.list}>
 			{(item) => {
@@ -74,7 +74,19 @@ function DirList(props: { list: Entry[] }) {
 								role="list"
 								class="ml-2 mt-2 space-y-3 border-l-[1px] border-slate-400 dark:border-slate-700 lg:border-slate-400"
 							>
-								<For each={item.children}>
+								<For
+									each={
+										props.sortAlphabeticaly
+											? item.children
+													.slice()
+													.sort((firstChild, secondChild) => {
+														return firstChild.title
+															.toLowerCase()
+															.localeCompare(secondChild.title.toLowerCase());
+													})
+											: item.children
+									}
+								>
 									{(child) => {
 										if (
 											Array.isArray(child.children) &&
@@ -100,7 +112,10 @@ function DirList(props: { list: Entry[] }) {
 																role="list"
 																class="ml-4 mt-3 space-y-3 border-l-[1px] border-slate-400 dark:border-slate-700 dark:lg:border-slate-700"
 															>
-																<DirList list={child.children} />
+																<DirList
+																	sortAlphabeticaly={props.sortAlphabeticaly}
+																	list={child.children}
+																/>
 															</ul>
 														</Collapsible.Content>
 													</Collapsible.Root>
@@ -171,7 +186,7 @@ export function MainNavigation(props: NavProps) {
 								fallback={<p>{i18n.t("main.nav.no.routes")}</p>}
 							>
 								<ul role="list" class="space-y-3 px-4">
-									<DirList list={reference()} />
+									<DirList sortAlphabeticaly list={reference()} />
 								</ul>
 							</Show>
 						</Tabs.Content>

--- a/src/ui/layout/main-navigation.tsx
+++ b/src/ui/layout/main-navigation.tsx
@@ -25,6 +25,14 @@ interface NavProps {
 	};
 }
 
+// gets an array of entries and orders it alphabeticaly
+const getAlphabeticalyOrderedList = (list: Entry[]) =>
+	list.slice().sort((firstChild, secondChild) => {
+		return firstChild.title
+			.toLowerCase()
+			.localeCompare(secondChild.title.toLowerCase());
+	});
+
 // check if every item on the list has mainNavExclude as true
 const shouldHideNavItem = (list: EntryList["learn" | "reference"]) =>
 	list.filter(({ mainNavExclude }) => mainNavExclude).length === list.length;
@@ -65,6 +73,9 @@ function DirList(props: { list: Entry[]; sortAlphabeticaly?: boolean }) {
 		<For each={props.list}>
 			{(item) => {
 				if (Array.isArray(item.children)) {
+					const itemChildren = props.sortAlphabeticaly
+						? getAlphabeticalyOrderedList(item.children)
+						: item.children;
 					return (
 						<li>
 							<span class="font-semibold text-slate-800 dark:text-slate-100">
@@ -74,19 +85,7 @@ function DirList(props: { list: Entry[]; sortAlphabeticaly?: boolean }) {
 								role="list"
 								class="ml-2 mt-2 space-y-3 border-l-[1px] border-slate-400 dark:border-slate-700 lg:border-slate-400"
 							>
-								<For
-									each={
-										props.sortAlphabeticaly
-											? item.children
-													.slice()
-													.sort((firstChild, secondChild) => {
-														return firstChild.title
-															.toLowerCase()
-															.localeCompare(secondChild.title.toLowerCase());
-													})
-											: item.children
-									}
-								>
+								<For each={itemChildren}>
 									{(child) => {
 										if (
 											Array.isArray(child.children) &&


### PR DESCRIPTION
Currently, our reference and learn section are ordered by how we define stuff in the respective `data.json`
We would like our reference to ignore that order, and just be alphabetically ordered.

What does it do?
- Adds an extra check during rendering the nav.
  - if rendering the reference section, orders alphabetically the items inside each section 