### PR TITLE
[Content]: Fix heading in stores page

### DIFF
--- a/src/routes/concepts/stores.mdx
+++ b/src/routes/concepts/stores.mdx
@@ -371,7 +371,7 @@ setData('animals', reconcile(newData))
 In this example, the store will look for the differences between the existing and incoming data sets.
 Consequently, only `'koala'` - the new edition - will cause an update.
 
-## Extracting raw data with `unwrap`
+### Extracting raw data with `unwrap`
 
 When there is a need for dealing with data outside of a reactive context, the `unwrap` utility offers a way to transform a store to a standard [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object).
 This conversion serves several important purposes.


### PR DESCRIPTION
As per #686 - `unwrap` should be a subsection of the store utilities section. 