### PR TITLE
[Content]: Typo in `fetching-data` guide

### DIFF
--- a/src/routes/guides/fetching-data.mdx
+++ b/src/routes/guides/fetching-data.mdx
@@ -172,7 +172,7 @@ When real-time feedback is necessary, the `refetch` method can be used to reload
 This method can be particularly useful when data is constantly evolving, such as with real-time financial applications.
 
 ```jsx
-import { createResource, onCleanUp } from 'solid-js';
+import { createResource, onCleanup } from 'solid-js';
 
 function StockPriceTicker() {
   const [prices, { refetch }] = createResource(fetchStockPrices);
@@ -180,6 +180,6 @@ function StockPriceTicker() {
   const timer = setInterval(() => {
     refetch()
   }, 1000);
-  onCleanUp(() => clearInterval(timer))
+  onCleanup(() => clearInterval(timer))
 }
 ```


### PR DESCRIPTION
As per #689 , fixing the typo present with `onCleanup`