### PR TITLE
Missing import in isServer docs

### DIFF
--- a/src/routes/reference/rendering/is-server.mdx
+++ b/src/routes/reference/rendering/is-server.mdx
@@ -11,6 +11,8 @@ This indicates that the code is being run as the server or browser bundle.
 As the underlying runtimes export this as a constant boolean it allows bundlers to eliminate the code and their used imports from the respective bundles.
 
 ```ts
+import { isServer } from "solid-js/web";
+
 if (isServer) {
 	// I will never make it to the browser bundle
 } else {


### PR DESCRIPTION
The page for isServer was confusing because the import was missing.