### PR TITLE
Add Show example that preserves an if-condition-then-else structure

### DIFF
--- a/src/routes/concepts/control-flow/conditional-rendering.mdx
+++ b/src/routes/concepts/control-flow/conditional-rendering.mdx
@@ -36,6 +36,19 @@ import { Show } from "solid-js"
 </Show>
 ```
 
+While simple, the above example has the undesirable trait of putting the else-clause before the then-clause, which subverts how programmers normally expect a conditional statement to read.
+The `children` property can be used to give the example above the usual _if-condition-then-else_ structure.
+
+```jsx
+import { Show } from "solid-js"
+
+<Show when={!data.loading} children={
+	<h1>Hi, I am {data().name}.</h1>
+} fallback={
+	<div>Loading...</div>
+} />
+```
+
 If there are multiple conditions that need to be handled, `<Show>` can be nested to handle each condition.
 
 ```jsx


### PR DESCRIPTION
Because the current example subverts an expectation practically every programmer has of how conditional statements work:
```
if condition then
    then-clause
else
    else-clause
```
I think this is a more usable pattern and it should be highlighted.