### PR TITLE
Expand info on `<A />` reference to include `<a />`

### DIFF
--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -5,7 +5,7 @@ title: A
 Like the [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) tag but supports relative paths and active class styling (requires client side JavaScript).
 
 The `<A>` tag has an `active` class if its href matches the current location, and `inactive` otherwise.
-**Note:** By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these.
+**Note:** By default matching includes locations that are descendants (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these.
 This is particularly useful for links to the root route `/` which would match everything.
 
 | prop          | type    | description                                                                                                                                                                              |
@@ -17,3 +17,20 @@ This is particularly useful for links to the root route `/` which would match ev
 | inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link)                                                                                           |
 | activeClass   | string  | The class to show when the link is active                                                                                                                                                |
 | end           | boolean | If `true`, only considers the link to be active when the current location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                     |
+
+## `<A />` vs `<a />`
+
+When JavaScript is present at the runtime, both components behave in a very similar fashion.
+This is because Solid-Router adds a listener at the top level of the DOM and will augment the native `<a />` tag to a more performant experience (with soft navigation).
+<A /> supports relative and base paths. <a /> doesn't. But <a /> gets augmented when JS is present via a top-level listener to the DOM, so you get the soft-navigation experience nonetheless.
+
+
+The `<A />` supports the `<Router />` base property (`<Router base="/subpath"`>`) and prepend it to the received `href` automatically and the `<a />` does not.
+The same happens with relative paths passed to `<A />`.
+
+
+<Callout type="tip">
+
+To prevent, both `<A />` and `<a />` tags from soft navigating when JavaScript is present, pass a `target="_self"` attribute.
+
+</Callout>

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -2,13 +2,13 @@
 title: A
 ---
 
-Solid-Router exposes an `<A />` component as a wrapper around the native `<a />` tag.
+Solid-Router exposes an `<A />` component as a wrapper around the native [`<a />`](https://mdn.io/a) tag.
 
 `<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
 when JS is present via a top-level listener to the DOM, so you get the
 soft-navigation experience nonetheless.
 
-The `<A />` supports the `<Router />` base property (`<Router base="/subpath">`) and prepend it to the received `href` automatically and the `<a />`does not.
+The `<A />` supports the [`<Router />`](/solid-router/reference/components/router) base property (`<Router base="/subpath">`) and prepend it to the received `href` automatically and the `<a />`does not.
 The same happens with relative paths passed to `<A />`.
 
 The `<A>` tag has an `active` class if its href matches the current location, and `inactive` otherwise.

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -2,11 +2,7 @@
 title: A
 ---
 
-Like the [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) tag but supports relative paths and active class styling (requires client side JavaScript).
-
 The `<A>` tag has an `active` class if its href matches the current location, and `inactive` otherwise.
-**Note:** By default matching includes locations that are descendants (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these.
-This is particularly useful for links to the root route `/` which would match everything.
 
 | prop          | type    | description                                                                                                                                                                              |
 | ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -18,18 +14,24 @@ This is particularly useful for links to the root route `/` which would match ev
 | activeClass   | string  | The class to show when the link is active                                                                                                                                                |
 | end           | boolean | If `true`, only considers the link to be active when the current location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                     |
 
-## `<A />` vs `<a />`
+By default matching includes locations that are descendants (e.g.: href `/users` matches locations `/users` and `/users/123`).
+
+<Callout type="tip">
+	Use the boolean `end` prop to prevent matching these. This is particularly
+	useful for links to the root route `/` which would match everything.
+</Callout>
 
 When JavaScript is present at the runtime, both components behave in a very similar fashion.
 This is because Solid-Router adds a listener at the top level of the DOM and will augment the native `<a />` tag to a more performant experience (with soft navigation).
-<A /> supports relative and base paths. <a /> doesn't. But <a /> gets augmented when JS is present via a top-level listener to the DOM, so you get the soft-navigation experience nonetheless.
 
+`<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
+when JS is present via a top-level listener to the DOM, so you get the
+soft-navigation experience nonetheless.
 
-The `<A />` supports the `<Router />` base property (`<Router base="/subpath"`>`) and prepend it to the received `href` automatically and the `<a />` does not.
+The `<A />` supports the `<Router />` base property (`<Router base="/subpath">`) and prepend it to the received `href` automatically and the `<a />`does not.
 The same happens with relative paths passed to `<A />`.
 
-
-<Callout type="tip">
+<Callout type="info">
 
 To prevent, both `<A />` and `<a />` tags from soft navigating when JavaScript is present, pass a `target="_self"` attribute.
 

--- a/src/routes/solid-router/reference/components/a.mdx
+++ b/src/routes/solid-router/reference/components/a.mdx
@@ -2,7 +2,35 @@
 title: A
 ---
 
+Solid-Router exposes an `<A />` component as a wrapper around the native `<a />` tag.
+
+`<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
+when JS is present via a top-level listener to the DOM, so you get the
+soft-navigation experience nonetheless.
+
+The `<A />` supports the `<Router />` base property (`<Router base="/subpath">`) and prepend it to the received `href` automatically and the `<a />`does not.
+The same happens with relative paths passed to `<A />`.
+
 The `<A>` tag has an `active` class if its href matches the current location, and `inactive` otherwise.
+By default matching includes locations that are descendants (e.g.: href `/users` matches locations `/users` and `/users/123`).
+
+<Callout type="tip">
+	Use the boolean `end` prop to prevent matching these. This is particularly
+	useful for links to the root route `/` which would match everything.
+</Callout>
+
+## Soft Navigation
+
+When JavaScript is present at the runtime, both components behave in a very similar fashion.
+This is because Solid-Router adds a listener at the top level of the DOM and will augment the native `<a />` tag to a more performant experience (with soft navigation).
+
+<Callout type="info">
+
+To prevent, both `<A />` and `<a />` tags from soft navigating when JavaScript is present, pass a `target="_self"` attribute.
+
+</Callout>
+
+## Props Reference
 
 | prop          | type    | description                                                                                                                                                                              |
 | ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -13,26 +41,3 @@ The `<A>` tag has an `active` class if its href matches the current location, an
 | inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link)                                                                                           |
 | activeClass   | string  | The class to show when the link is active                                                                                                                                                |
 | end           | boolean | If `true`, only considers the link to be active when the current location matches the `href` exactly; if `false`, check if the current location _starts with_ `href`                     |
-
-By default matching includes locations that are descendants (e.g.: href `/users` matches locations `/users` and `/users/123`).
-
-<Callout type="tip">
-	Use the boolean `end` prop to prevent matching these. This is particularly
-	useful for links to the root route `/` which would match everything.
-</Callout>
-
-When JavaScript is present at the runtime, both components behave in a very similar fashion.
-This is because Solid-Router adds a listener at the top level of the DOM and will augment the native `<a />` tag to a more performant experience (with soft navigation).
-
-`<A />` supports relative and base paths. `<a />` doesn't. But `<a />` gets augmented
-when JS is present via a top-level listener to the DOM, so you get the
-soft-navigation experience nonetheless.
-
-The `<A />` supports the `<Router />` base property (`<Router base="/subpath">`) and prepend it to the received `href` automatically and the `<a />`does not.
-The same happens with relative paths passed to `<A />`.
-
-<Callout type="info">
-
-To prevent, both `<A />` and `<a />` tags from soft navigating when JavaScript is present, pass a `target="_self"` attribute.
-
-</Callout>


### PR DESCRIPTION
- difference between `<A />` and `<a />`
- preventing soft navigation