### PR TITLE
fix(docs): list capitalization consistency

### DIFF
--- a/src/routes/solid-start/building-your-application/api-routes.mdx
+++ b/src/routes/solid-start/building-your-application/api-routes.mdx
@@ -4,11 +4,11 @@ title: "API routes"
 
 While Server Functions can be a good way to write server-side code for data needed by your UI, sometimes you need to expose API routes.
 Some reasons for wanting API Routes include:
-- there are additional clients that want to share this logic.
-- exposing a GraphQL or tRPC endpoint.
-- exposing a public facing REST API.
-- writing webhooks or auth callback handlers for OAuth.
-- having URLs not serving HTML, but other kinds of documents like PDFs or images.
+- There are additional clients that want to share this logic.
+- Exposing a GraphQL or tRPC endpoint.
+- Exposing a public facing REST API.
+- Writing webhooks or auth callback handlers for OAuth.
+- Having URLs not serving HTML, but other kinds of documents like PDFs or images.
 
 For these use cases, SolidStart provides a way to write these routes in a way that is easy to understand and maintain. 
 API routes are just similar to other routes and follow the same filename conventions as [UI Routes](/solid-start/building-your-application/routing).


### PR DESCRIPTION
Everywhere else in the docs the lists are written with capitalized first letter.