### PR TITLE
fix(docs): incorrect type for portal's mount prop

### DIFF
--- a/src/routes/concepts/control-flow/portal.mdx
+++ b/src/routes/concepts/control-flow/portal.mdx
@@ -22,7 +22,7 @@ The content nested within `<Portal>` is rendered and positioned by default at th
 />
 
 This can be changed by passing a `mount` prop to `<Portal>`.
-The `mount` prop accepts a function that returns a [DOM node](https://developer.mozilla.org/en-US/docs/Web/API/Node), which will be used as the mount point for the portal content.
+The `mount` prop accepts a [DOM node](https://developer.mozilla.org/en-US/docs/Web/API/Node), which will be used as the mount point for the portal content.
 
 ```jsx
 import { Portal } from "solid-js/web"


### PR DESCRIPTION
The `mount` prop accepts a DOM node but docs say that it accepts a "function that returns a DOM Node" which is incorrect