### PR TITLE
fix(docs): remove redundant separator

### DIFF
--- a/src/routes/solid-router/concepts/dynamic-routes.mdx
+++ b/src/routes/solid-router/concepts/dynamic-routes.mdx
@@ -84,8 +84,6 @@ So in this example:
 - `/users/mom/me/contact.html` would not match as `:id` is not a number,
 - `/users/dad/123/contact` would not match as `:withHtmlExtension` is missing `.html`.
 
----
-
 ## Optional parameters
 
 Parameters can be specified as optional by adding a question mark to the end of the parameter name:


### PR DESCRIPTION
There is a heading below this section, markdown automatically adds a separator. This change de-duplicates this separator.