### PR TITLE
Typo in createResource example user type

### DIFF
--- a/src/routes/solid-start/building-your-application/data-loading.mdx
+++ b/src/routes/solid-start/building-your-application/data-loading.mdx
@@ -15,7 +15,7 @@ It takes an async function and returns a [signal](/reference/basic-reactivity/cr
 ```tsx {6-9}
 import { For, createResource } from "solid-js";
 
-type Users = { name: string; house: string };
+type User = { name: string; house: string };
 
 export default function Page() {
 	const [users] = createResource(async () => {


### PR DESCRIPTION
In `Data loading on the client` code snippet, there is a silly typo of User type.


![CleanShot 2024-05-25 at 3  07 55@2x](https://github.com/solidjs/solid-docs-next/assets/7611746/614b34a4-b616-40d3-afc3-9827c03fdb66)


https://docs.solidjs.com/solid-start/building-your-application/data-loading#data-loading-on-the-client