### PR TITLE
fix: internal link opening in a new tab

### DIFF
--- a/src/routes/solid-start/advanced/auth.mdx
+++ b/src/routes/solid-start/advanced/auth.mdx
@@ -17,7 +17,7 @@ async function getPrivatePosts() {
 }
 ```
 
-The `getUser` function can be [implemented using sessions](https://docs.solidjs.com/solid-start/advanced/session).
+The `getUser` function can be [implemented using sessions](/solid-start/advanced/session).
 
 ## Protected Routes
 


### PR DESCRIPTION
In https://docs.solidjs.com/solid-start/advanced/auth clicking on implemented using sessions opens it up in a new tab.

This PR Fixes that.  