### PR TITLE
typo: solid start index.mdx

### DIFF
--- a/src/routes/solid-start/index.mdx
+++ b/src/routes/solid-start/index.mdx
@@ -24,7 +24,7 @@ A driving principle of SolidStart is that code should be _isomorphic_ &mdash; th
 
 SolidStart features the following capabilities:
 
-- **Fine-grained reactivity** &mdash; Powered by SolidJS and it's fine-grained reactivity.
+- **Fine-grained reactivity** &mdash; Powered by SolidJS and its fine-grained reactivity.
 - **Isomorphic, nested routing** &mdash; The same routes are rendered regardless of whether the page is on the client or server.
   Route nesting provides parent-child relationships that simplify application logic.
 - **Multiple rendering modes** &mdash; Can be used to create CSR, SSR (Sync, Async and Streaming), and SSG applications.


### PR DESCRIPTION
fixed grammar:
from
"it's fine-grained reactivity"
to
"its fine-grained reactivity"

"it's" means "it is". "its" is the correct usage here.