### PR TITLE
fix: typo in define-config.mdx

### DIFF
--- a/src/routes/solid-start/reference/config/define-config.mdx
+++ b/src/routes/solid-start/reference/config/define-config.mdx
@@ -58,7 +58,7 @@ An overview of all available presets is available in the [Deploy section of the 
 **Providers**
 
 - [Netlify Functions and Edge](https://nitro.unjs.io/deploy/providers/netlify) (`netlify`, `netlify-edge`)
-- [Vercel Functions and Edge](https://nitro.unjs.io/deploy/providers/vercel) (`vecel`, `vecel-edge`)
+- [Vercel Functions and Edge](https://nitro.unjs.io/deploy/providers/vercel) (`vercel`, `vercel-edge`)
 - [AWS Lambda and Lambda@Edge](https://nitro.unjs.io/deploy/providers/aws) (`aws_lambda`)
 - [Cloudflare Workers and Pages](https://nitro.unjs.io/deploy/providers/cloudflare) (`cloudflare`, `cloudflare_pages`, `cloudflare_module`)
 - [Deno Deploy](https://nitro.unjs.io/deploy/providers/deno-deploy) (`deno_deploy`)


### PR DESCRIPTION
found this small typo while trying to deploy my solid-start app to vercel